### PR TITLE
disabling System Media Transport Controls on MediaPlayer

### DIFF
--- a/Tools/Cam360/MainPage.xaml.cs
+++ b/Tools/Cam360/MainPage.xaml.cs
@@ -617,6 +617,7 @@ namespace Cam360
             _mediaPlayer.RealTimePlayback = true;
             _mediaPlayer.AutoPlay = true;
             _mediaPlayer.Source = MediaSource.CreateFromMediaFrameSource(_selectedFrameSource);
+            _mediaPlayer.CommandManager.IsEnabled = false;
             PreviewElement.SetMediaPlayer(_mediaPlayer);
             _mediaPlayerProjection = _mediaPlayer.PlaybackSession.SphericalVideoProjection;
 


### PR DESCRIPTION
disabling System Media Transport Controls so that when system media events are triggered (i.e. volume down, up, play, pause, etc.) the app is not handling them nor appear to do so from shell