### PR TITLE
Fixed schannel compat bug with newer versions and other misc fixes

### DIFF
--- a/Samples/NetworkMediaStreamer/CameraRTPStreamerApp/CameraRTPStreamerApp.cpp
+++ b/Samples/NetworkMediaStreamer/CameraRTPStreamerApp/CameraRTPStreamerApp.cpp
@@ -40,7 +40,7 @@ constexpr uint16_t ServerPort = 8554;
 constexpr uint16_t SecureServerPort = 6554;
 
 // Uncomment the following if you want to use FrameReader API instead of the Record-to-sink APIs
-#define USE_FR 
+//#define USE_FR 
 
 // sample test code to get localhost test certificate
 std::vector<PCCERT_CONTEXT> getServerCertificate()
@@ -208,7 +208,7 @@ winrt::hstring GetDeviceSelectionFromUser()
     {
         std::cout << "\nEnter Selection:";
         std::cin >> selection; selection--;
-    } while ((selection < 0) || (selection > filteredDevices.Size()));
+    } while ((selection < 0) || (selection > (int)filteredDevices.Size()));
 
     return filteredDevices.GetAt(selection).Id();
 }

--- a/Samples/NetworkMediaStreamer/CameraRTPStreamerApp/CameraRTPStreamerApp.cpp
+++ b/Samples/NetworkMediaStreamer/CameraRTPStreamerApp/CameraRTPStreamerApp.cpp
@@ -40,6 +40,8 @@ constexpr uint16_t ServerPort = 8554;
 constexpr uint16_t SecureServerPort = 6554;
 
 // Uncomment the following if you want to use FrameReader API instead of the Record-to-sink APIs
+// Using FrameReader API allows the app to handle/process/modify the sample before streaming out.
+// Using Mediacapture Record-to-Sink APIs takes the per sample handling burden away from the App
 //#define USE_FR 
 
 // sample test code to get localhost test certificate

--- a/Samples/NetworkMediaStreamer/RTSPServer/inc/pch.h
+++ b/Samples/NetworkMediaStreamer/RTSPServer/inc/pch.h
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for more information
 
 #pragma once
-#ifndef UNICODE
-#define UNICODE
-#endif
+
 #define SECURITY_WIN32
 #include <WinSock2.h>
 #include <windows.h>
@@ -12,8 +10,6 @@
 #include <mutex>
 
 #include <Security.h>
-#include <winternl.h>
-#define SCHANNEL_USE_BLACKLISTS
 #include <schnlsp.h>
 
 #include <ws2def.h>
@@ -25,6 +21,7 @@
 #include <sstream>
 #include <winrt\base.h>
 #include <winrt\Windows.Foundation.h>
+#include <winrt\Windows.Foundation.Collections.h>
 #include <winrt\windows.system.threading.h>
 #include <winrt\Windows.Security.Cryptography.h>
 #include <winrt\Windows.Security.Cryptography.Core.h>

--- a/Samples/NetworkMediaStreamer/RTSPServer/src/RTSPAuthProvider.cpp
+++ b/Samples/NetworkMediaStreamer/RTSPServer/src/RTSPAuthProvider.cpp
@@ -5,6 +5,7 @@
 
 using namespace winrt::Windows::Security;
 using namespace winrt::Windows::Security::Credentials;
+using namespace winrt::Windows::Foundation::Collections;
 using namespace Cryptography::Core;
 using namespace Cryptography;
 

--- a/Samples/NetworkMediaStreamer/RTSPServer/src/SocketWrapper.cpp
+++ b/Samples/NetworkMediaStreamer/RTSPServer/src/SocketWrapper.cpp
@@ -133,12 +133,12 @@ void CSocketWrapper::InitializeSecurity()
     FreeContextBuffer(pPkgInfo);
 
     // Perform Handshake
-    SCH_CREDENTIALS credData;
+    SCHANNEL_CRED credData;
     ZeroMemory(&credData, sizeof(credData));
-    credData.dwVersion = SCH_CREDENTIALS_VERSION;
-    credData.dwCredFormat = SCH_CRED_FORMAT_CERT_HASH;
+    credData.dwVersion = SCHANNEL_CRED_VERSION;
     credData.cCreds = (DWORD)m_aCertContext.size();
     credData.paCred = m_aCertContext.data();
+    credData.dwCredFormat = SCH_CRED_FORMAT_CERT_HASH;
 
     winrt::check_hresult(AcquireCredentialsHandle(
         NULL,


### PR DESCRIPTION
1. Removed the use of SCHANNEL_USE_BLACKLISTS which caused the TLS handshake to fail in newer versions of schannel.dll
2. Fixed warnings and build errors with newer SDKs 