### PR TITLE
fixing issues with the sample and adding support for EVComp

### DIFF
--- a/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.cpp
+++ b/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.cpp
@@ -75,7 +75,7 @@ namespace winrt::DefaultControlHelper::implementation
         // check if there is an existing entry for this control to store a default value
         auto collection = m_controlManager.get()->GetCollection();
         auto count = collection->GetControlCount();
-        m_hasDefaultValueStored = false;
+        
         if (count > 0)
         {
             wil::com_ptr<IMFCameraControlDefaults> existingControlDefaults;

--- a/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.h
+++ b/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.h
@@ -37,7 +37,7 @@ namespace winrt::DefaultControlHelper::implementation
 
     private:
 
-        bool m_hasDefaultValueStored;
+        bool m_hasDefaultValueStored = false;
         std::optional<MF_CAMERA_CONTROL_RANGE_INFO> m_rangeInfo;
         wil::com_ptr<IMFCameraControlDefaults> m_controlDefaults;
 

--- a/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.h
+++ b/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.h
@@ -24,90 +24,71 @@ namespace winrt::DefaultControlHelper::implementation
 
     private:
 
-        wil::com_ptr_t<IMFCameraConfigurationManager>           m_configManager;
-        wil::com_ptr_t<IMFCameraControlDefaultsCollection>      m_controlDefaultsCollection;
+        wil::com_ptr_t<IMFCameraConfigurationManager> m_configManager;
+        wil::com_ptr_t<IMFCameraControlDefaultsCollection> m_controlDefaultsCollection;
     };
 
     struct DefaultController : DefaultControllerT<DefaultController>
     {
-        DefaultController(winrt::DefaultControlHelper::DefaultControllerType type, uint32_t id, winrt::weak_ref<DefaultControlManager> manager);
-
-        uint32_t DefaultValue();
-        void DefaultValue(uint32_t const& value);
+        DefaultController(winrt::DefaultControlHelper::DefaultControllerType type, uint32_t id, winrt::com_ptr<DefaultControlManager> manager);
+        bool HasDefaultValueStored() { return m_hasDefaultValueStored; }
+        int32_t DefaultValue();
+        void DefaultValue(int32_t const& value);
 
     private:
 
-        uint32_t    m_defaultValue = 0;
-        std::optional<MF_CAMERA_CONTROL_RANGE_INFO>     m_rangeInfo;
-        wil::com_ptr<IMFCameraControlDefaults>          m_controlDefaults;
+        bool m_hasDefaultValueStored;
+        std::optional<MF_CAMERA_CONTROL_RANGE_INFO> m_rangeInfo;
+        wil::com_ptr<IMFCameraControlDefaults> m_controlDefaults;
 
-        
-        uint32_t    m_id = 0;
-        winrt::weak_ref<DefaultControlManager>          m_controlManager;
+        uint32_t m_id = 0;
+        winrt::guid m_setGuid;
+        winrt::com_ptr<DefaultControlManager> m_controlManager;
 
-        std::unique_ptr<IDefaultControllerInternal>     m_internalController;
+        std::unique_ptr<IDefaultControllerInternal> m_internalController;
     };
 
     // This is a helper interface and classes to handle
     // different kind of camera control structures.
     struct IDefaultControllerInternal
     {
-        virtual void SaveDefault(const wil::com_ptr<IMFCameraControlDefaults>&, const uint32_t) = 0;
-        virtual void Initialize(const winrt::com_ptr<DefaultControlManager>&, wil::com_ptr<IMFCameraControlDefaults>&, const uint32_t) = 0;
-
+        virtual void SaveDefault(void* pControl, ULONG controlSize, void* pData, ULONG dataSize, int32_t const& value) = 0;
+        virtual int32_t GetStoredDefaultValue(void* control, ULONG controlSize, void* data, ULONG dataSize) = 0;
+        virtual void Initialize(winrt::com_ptr<DefaultControlManager> manager, wil::com_ptr<IMFCameraControlDefaults>& defaults, winrt::guid setGuid, uint32_t id) = 0;
         virtual ~IDefaultControllerInternal() = default;
     };
 
     class DefaultControllerVidCapVideoProcAmp : public IDefaultControllerInternal
     {
     public:
-        virtual void SaveDefault(const wil::com_ptr<IMFCameraControlDefaults>&, const uint32_t value) override;
+        virtual void SaveDefault(void* pControl, ULONG controlSize, void* pData, ULONG dataSize, int32_t const& value) override;
+        virtual int32_t GetStoredDefaultValue(void* control, ULONG controlSize, void* data, ULONG dataSize) override;
 
-        virtual void Initialize(winrt::com_ptr<DefaultControlManager> const& manager, wil::com_ptr<IMFCameraControlDefaults>&, const uint32_t id) override;
+        virtual void Initialize(winrt::com_ptr<DefaultControlManager> manager, wil::com_ptr<IMFCameraControlDefaults>& defaults, winrt::guid setGuid, uint32_t id) override;
         
         virtual ~DefaultControllerVidCapVideoProcAmp() = default;
-    private:
-        const winrt::guid m_typeGuid{ PROPSETID_VIDCAP_VIDEOPROCAMP };
-
-    };
-
-    class DefaultControllerCameraControl : public IDefaultControllerInternal
-    {
-    public:
-        virtual void SaveDefault(const wil::com_ptr<IMFCameraControlDefaults>&, const uint32_t value) override;
-
-        virtual void Initialize(const winrt::com_ptr<DefaultControlManager>& manager, wil::com_ptr<IMFCameraControlDefaults>&, const uint32_t id) override;
-
-        virtual ~DefaultControllerCameraControl() = default;
-
-    private:
-        const winrt::guid m_typeGuid{ PROPSETID_VIDCAP_CAMERACONTROL };
     };
 
     class DefaultControllerExtendedControl : public IDefaultControllerInternal
     {
     public:
-        virtual void SaveDefault(const wil::com_ptr<IMFCameraControlDefaults>&, const uint32_t value) override;
+        virtual void SaveDefault(void* pControl, ULONG controlSize, void* pData, ULONG dataSize, int32_t const& value) override;
+        virtual int32_t GetStoredDefaultValue(void* control, ULONG controlSize, void* data, ULONG dataSize) override;
 
-        virtual void Initialize (const winrt::com_ptr<DefaultControlManager>& manager, wil::com_ptr<IMFCameraControlDefaults>&, const uint32_t id) override;
+        virtual void Initialize(winrt::com_ptr<DefaultControlManager> manager, wil::com_ptr<IMFCameraControlDefaults>& defaults, winrt::guid setGuid, uint32_t id) override;
 
-        virtual ~DefaultControllerExtendedControl() = default;
-
-    private:
-        const winrt::guid m_typeGuid{ KSPROPERTYSETID_ExtendedCameraControl };
+        virtual ~DefaultControllerExtendedControl() = default;        
     };
 
     class DefaultControllerEVCompExtendedControl : public IDefaultControllerInternal
     {
     public:
-        virtual void SaveDefault(const wil::com_ptr<IMFCameraControlDefaults>&, const uint32_t value) override;
+        virtual void SaveDefault(void* pControl, ULONG controlSize, void* pData, ULONG dataSize, int32_t const& value) override;
+        virtual int32_t GetStoredDefaultValue(void* control, ULONG controlSize, void* data, ULONG dataSize) override;
 
-        virtual void Initialize(const winrt::com_ptr<DefaultControlManager>& manager, wil::com_ptr<IMFCameraControlDefaults>&, const uint32_t id = KSPROPERTY_CAMERACONTROL_EXTENDED_EVCOMPENSATION) override;
+        virtual void Initialize(winrt::com_ptr<DefaultControlManager> manager, wil::com_ptr<IMFCameraControlDefaults>& defaults, winrt::guid setGuid, uint32_t id) override;
 
         virtual ~DefaultControllerEVCompExtendedControl() = default;
-
-    private:
-        const winrt::guid m_typeGuid{ KSPROPERTYSETID_ExtendedCameraControl };
     };
 }
 

--- a/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.h
+++ b/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.h
@@ -37,12 +37,12 @@ namespace winrt::DefaultControlHelper::implementation
 
     private:
 
-        uint32_t                                        m_defaultValue = 0;
+        uint32_t    m_defaultValue = 0;
         std::optional<MF_CAMERA_CONTROL_RANGE_INFO>     m_rangeInfo;
         wil::com_ptr<IMFCameraControlDefaults>          m_controlDefaults;
 
         
-        uint32_t                                        m_id = 0;
+        uint32_t    m_id = 0;
         winrt::weak_ref<DefaultControlManager>          m_controlManager;
 
         std::unique_ptr<IDefaultControllerInternal>     m_internalController;
@@ -67,7 +67,7 @@ namespace winrt::DefaultControlHelper::implementation
         
         virtual ~DefaultControllerVidCapVideoProcAmp() = default;
     private:
-        const winrt::guid                                     m_typeGuid{ PROPSETID_VIDCAP_VIDEOPROCAMP };
+        const winrt::guid m_typeGuid{ PROPSETID_VIDCAP_VIDEOPROCAMP };
 
     };
 
@@ -81,7 +81,7 @@ namespace winrt::DefaultControlHelper::implementation
         virtual ~DefaultControllerCameraControl() = default;
 
     private:
-        const winrt::guid                                     m_typeGuid{ PROPSETID_VIDCAP_CAMERACONTROL };
+        const winrt::guid m_typeGuid{ PROPSETID_VIDCAP_CAMERACONTROL };
     };
 
     class DefaultControllerExtendedControl : public IDefaultControllerInternal
@@ -94,7 +94,20 @@ namespace winrt::DefaultControlHelper::implementation
         virtual ~DefaultControllerExtendedControl() = default;
 
     private:
-        const winrt::guid                                     m_typeGuid{ KSPROPERTYSETID_ExtendedCameraControl };
+        const winrt::guid m_typeGuid{ KSPROPERTYSETID_ExtendedCameraControl };
+    };
+
+    class DefaultControllerEVCompExtendedControl : public IDefaultControllerInternal
+    {
+    public:
+        virtual void SaveDefault(const wil::com_ptr<IMFCameraControlDefaults>&, const uint32_t value) override;
+
+        virtual void Initialize(const winrt::com_ptr<DefaultControlManager>& manager, wil::com_ptr<IMFCameraControlDefaults>&, const uint32_t id = KSPROPERTY_CAMERACONTROL_EXTENDED_EVCOMPENSATION) override;
+
+        virtual ~DefaultControllerEVCompExtendedControl() = default;
+
+    private:
+        const winrt::guid m_typeGuid{ KSPROPERTYSETID_ExtendedCameraControl };
     };
 }
 

--- a/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.idl
+++ b/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.idl
@@ -4,17 +4,19 @@
 
 namespace DefaultControlHelper
 {
+    // each enum value correspond to a type of camera control also known as a "property set"
     enum DefaultControllerType
     {
-        VideoProcAmp,
-        CameraControl,
-        ExtendedCameraControl,
+        VideoProcAmp,// correlates with properties under the set PROPSETID_VIDCAP_VIDEOPROCAMP
+        CameraControl, // correlates with properties under the set PROPSETID_VIDCAP_CAMERACONTROL
+        ExtendedCameraControl, // correlates with properties under the set KSPROPERTYSETID_ExtendedCameraControl
     };
  
     
     runtimeclass DefaultController
     {
-        UInt32 DefaultValue;
+        Boolean HasDefaultValueStored();
+        Int32 DefaultValue;
     }
 
     [default_interface]

--- a/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/MainPage.xaml
+++ b/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/MainPage.xaml
@@ -13,6 +13,7 @@
         <StackPanel>
             <TextBlock x:Name="SelectedCameraTB"/>
             <MediaPlayerElement x:Name="UIMediaPlayerElement" AreTransportControlsEnabled="False"/>
+            <TextBox x:Name="UITextOutput" TextWrapping="Wrap"/>
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10" HorizontalAlignment="Center">
                 <TextBlock
                     x:Uid="DefaultContrast"

--- a/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/MainPage.xaml
+++ b/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/MainPage.xaml
@@ -16,6 +16,7 @@
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10" HorizontalAlignment="Center">
                 <TextBlock
                     x:Uid="DefaultContrast"
+                    Text="Contrast"
                     Visibility="{Binding ElementName=DefaultContrastSlider, Path=Visibility}"
                     VerticalAlignment="Center" />
                 <Slider 
@@ -35,6 +36,7 @@
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10" HorizontalAlignment="Center">
                 <TextBlock
                     x:Uid="DefaultBrightness"
+                    Text="Brightness"
                     Visibility="{Binding ElementName=DefaultBrightnessSlider, Path=Visibility}"
                     VerticalAlignment="Center" />
                 <Slider 
@@ -54,6 +56,7 @@
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10" HorizontalAlignment="Center">
                 <TextBlock
                     x:Uid="DefaultBlur"
+                    Text="Blur"
                     Visibility="{Binding ElementName=DefaultBlurToggle, Path=Visibility}"
                     VerticalAlignment="Center" />
                 <ToggleSwitch 
@@ -61,6 +64,26 @@
                     x:Uid="DefaultBlurToggle"
                     AutomationProperties.LabeledBy="{Binding ElementName=DefaultBlur}"
                     Toggled="DefaultBlurToggle_Toggled"
+                    HorizontalAlignment="Center"
+                    MaxWidth="300"
+                    MinWidth="200"
+                    Visibility="Collapsed"
+                    VerticalAlignment="Center"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10" HorizontalAlignment="Center">
+                <TextBlock
+                    x:Uid="DefaultEVComp"
+                    Text="EVCompensation"
+                    Visibility="{Binding ElementName=DefaultEVCompSlider, Path=Visibility}"
+                    VerticalAlignment="Center" />
+                <Slider 
+                    x:Name="DefaultEVCompSlider"
+                    x:Uid="DefaultEVCompSlider"
+                    AutomationProperties.LabeledBy="{Binding ElementName=DefaultEVComp}"
+                    Minimum="0"
+                    Maximum="100"
+                    StepFrequency="1"
+                    ValueChanged="DefaultEVCompSlider_ValueChanged"
                     HorizontalAlignment="Center"
                     MaxWidth="300"
                     MinWidth="200"

--- a/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/MainPage.xaml.cs
+++ b/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/MainPage.xaml.cs
@@ -75,147 +75,231 @@ namespace OutboundSettingsAppTest
         }
         private async Task InitializeAsync()
         {
-            m_mediaCapture = new MediaCapture();
-            m_mediaPlayer = new MediaPlayer();
-
-            // We initialize the MediaCapture instance with the virtual camera in sharing mode
-            // to preview its stream without blocking other app from using it
-            var initSettings = new MediaCaptureInitializationSettings()
+            try
             {
-                SharingMode = MediaCaptureSharingMode.ExclusiveControl,
-                VideoDeviceId = cameraId,
-                StreamingCaptureMode = StreamingCaptureMode.Video
-            };
+                m_mediaCapture = new MediaCapture();
+                m_mediaPlayer = new MediaPlayer();
 
-            await m_mediaCapture.InitializeAsync(initSettings);
+                // We initialize the MediaCapture instance with the virtual camera in sharing mode
+                // to preview its stream without blocking other app from using it
+                var initSettings = new MediaCaptureInitializationSettings()
+                {
+                    SharingMode = MediaCaptureSharingMode.ExclusiveControl,
+                    VideoDeviceId = cameraId,
+                    StreamingCaptureMode = StreamingCaptureMode.Video
+                };
 
-            // Retrieve the source associated with the video preview stream.
-            // On 1-pin camera, this may be the VideoRecord MediaStreamType as opposed to VideoPreview on multi-pin camera
-            var frameSource = m_mediaCapture.FrameSources.FirstOrDefault(source => source.Value.Info.MediaStreamType == MediaStreamType.VideoPreview
-                                                                              && source.Value.Info.SourceKind == MediaFrameSourceKind.Color).Value;
-            if (frameSource == null)
-            {
-                frameSource = m_mediaCapture.FrameSources.FirstOrDefault(source => source.Value.Info.MediaStreamType == MediaStreamType.VideoRecord
+                await m_mediaCapture.InitializeAsync(initSettings);
+
+                // Retrieve the source associated with the video preview stream.
+                // On 1-pin camera, this may be the VideoRecord MediaStreamType as opposed to VideoPreview on multi-pin camera
+                var frameSource = m_mediaCapture.FrameSources.FirstOrDefault(source => source.Value.Info.MediaStreamType == MediaStreamType.VideoPreview
                                                                                   && source.Value.Info.SourceKind == MediaFrameSourceKind.Color).Value;
-            }
-
-            // if no preview stream is available, bail
-            if (frameSource == null)
-            {
-                return;
-            }
-
-            // Setup MediaPlayer with the preview source
-            m_mediaPlayer.RealTimePlayback = true;
-            m_mediaPlayer.AutoPlay = true;
-            m_mediaPlayer.Source = MediaSource.CreateFromMediaFrameSource(frameSource);
-            UIMediaPlayerElement.SetMediaPlayer(m_mediaPlayer);
-
-            // Creating a default contol manager and controls for Contrast, Brightness, and BackgroundSegmentation/Blur if the camera supports these.
-            m_controlManager = new DefaultControlHelper.DefaultControlManager(cameraId);
-
-            // Contrast
-            if (m_mediaCapture.VideoDeviceController.Contrast.Capabilities.Supported)
-            {
-                m_contrastController = m_controlManager.CreateController(DefaultControlHelper.DefaultControllerType.VideoProcAmp, (uint) CameraKsPropertyHelper.VidCapVideoProcAmpKind.KSPROPERTY_VIDEOPROCAMP_CONTRAST);
-            }
-
-            // Brightness
-            if (m_mediaCapture.VideoDeviceController.Brightness.Capabilities.Supported)
-            {
-                m_brightnessController = m_controlManager.CreateController(DefaultControlHelper.DefaultControllerType.VideoProcAmp,(uint) CameraKsPropertyHelper.VidCapVideoProcAmpKind.KSPROPERTY_VIDEOPROCAMP_BRIGHTNESS);
-            }
-
-            // EVComp
-            if (m_mediaCapture.VideoDeviceController.ExposureCompensationControl.Supported)
-            {
-                m_evCompController = m_controlManager.CreateController(DefaultControlHelper.DefaultControllerType.ExtendedCameraControl, (uint)CameraKsPropertyHelper.ExtendedControlKind.KSPROPERTY_CAMERACONTROL_EXTENDED_EVCOMPENSATION);
-            }
-
-            // Blur
-            bool isDeviceControlSupported = false;
-            IExtendedPropertyPayload getPayload = null;
-
-            getPayload = PropertyInquiry.GetExtendedControl(m_mediaCapture.VideoDeviceController, ExtendedControlKind.KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION);
-            isDeviceControlSupported = (getPayload != null);
-            if (isDeviceControlSupported && (((ulong)BackgroundSegmentationCapabilityKind.KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR & ~getPayload.Capability) == 0))
-            {
-                m_backgroundBlurController = m_controlManager.CreateController(DefaultControlHelper.DefaultControllerType.ExtendedCameraControl, (uint) ExtendedControlKind.KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION);
-            }
-
-            // Updating UI elements
-            await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
-            {
-                // The sliders is initialized to work with the values that driver provides as supported range and step
-                if (m_contrastController != null)
+                if (frameSource == null)
                 {
-                    DefaultContrastSlider.ValueChanged -= DefaultContrastSlider_ValueChanged;
-                    DefaultContrastSlider.Minimum = m_mediaCapture.VideoDeviceController.Contrast.Capabilities.Min;
-                    DefaultContrastSlider.Maximum = m_mediaCapture.VideoDeviceController.Contrast.Capabilities.Max;
-                    DefaultContrastSlider.StepFrequency = m_mediaCapture.VideoDeviceController.Contrast.Capabilities.Step;
-                    DefaultContrastSlider.Visibility = Visibility.Visible;
-                    DefaultContrastSlider.Value = m_contrastController.DefaultValue;
-                    DefaultContrastSlider.ValueChanged += DefaultContrastSlider_ValueChanged;
+                    frameSource = m_mediaCapture.FrameSources.FirstOrDefault(source => source.Value.Info.MediaStreamType == MediaStreamType.VideoRecord
+                                                                                      && source.Value.Info.SourceKind == MediaFrameSourceKind.Color).Value;
                 }
 
-                if (m_brightnessController != null)
+                // if no preview stream is available, bail
+                if (frameSource == null)
                 {
-                    DefaultBrightnessSlider.ValueChanged -= DefaultBrightnessSlider_ValueChanged;
-                    DefaultBrightnessSlider.Minimum = m_mediaCapture.VideoDeviceController.Brightness.Capabilities.Min;
-                    DefaultBrightnessSlider.Maximum = m_mediaCapture.VideoDeviceController.Brightness.Capabilities.Max;
-                    DefaultBrightnessSlider.StepFrequency = m_mediaCapture.VideoDeviceController.Brightness.Capabilities.Step;
-                    DefaultBrightnessSlider.Visibility = Visibility.Visible;
-                    DefaultBrightnessSlider.Value = m_brightnessController.DefaultValue;
-                    DefaultBrightnessSlider.ValueChanged -= DefaultBrightnessSlider_ValueChanged;
+                    return;
                 }
-                if (m_evCompController != null)
+
+                // Setup MediaPlayer with the preview source
+                m_mediaPlayer.RealTimePlayback = true;
+                m_mediaPlayer.AutoPlay = true;
+                m_mediaPlayer.Source = MediaSource.CreateFromMediaFrameSource(frameSource);
+                UIMediaPlayerElement.SetMediaPlayer(m_mediaPlayer);
+
+                // Creating a default contol manager and controls for Contrast, Brightness, and BackgroundSegmentation/Blur if the camera supports these.
+                m_controlManager = new DefaultControlHelper.DefaultControlManager(cameraId);
+
+                // Contrast
+                if (m_mediaCapture.VideoDeviceController.Contrast.Capabilities.Supported)
                 {
-                    DefaultEVCompSlider.ValueChanged -= DefaultEVCompSlider_ValueChanged;
-                    DefaultEVCompSlider.Minimum = m_mediaCapture.VideoDeviceController.ExposureCompensationControl.Min;
-                    DefaultEVCompSlider.Maximum = m_mediaCapture.VideoDeviceController.ExposureCompensationControl.Max;
-                    DefaultEVCompSlider.StepFrequency = m_mediaCapture.VideoDeviceController.ExposureCompensationControl.Step;
-                    DefaultEVCompSlider.Visibility = Visibility.Visible;
-                    DefaultEVCompSlider.Value = m_evCompController.DefaultValue;
-                    if(DefaultEVCompSlider.Value > DefaultEVCompSlider.Maximum || DefaultEVCompSlider.Value < DefaultEVCompSlider.Minimum)
+                    m_contrastController = m_controlManager.CreateController(DefaultControlHelper.DefaultControllerType.VideoProcAmp, (uint)CameraKsPropertyHelper.VidCapVideoProcAmpKind.KSPROPERTY_VIDEOPROCAMP_CONTRAST);
+                }
+
+                // Brightness
+                if (m_mediaCapture.VideoDeviceController.Brightness.Capabilities.Supported)
+                {
+                    m_brightnessController = m_controlManager.CreateController(DefaultControlHelper.DefaultControllerType.VideoProcAmp, (uint)CameraKsPropertyHelper.VidCapVideoProcAmpKind.KSPROPERTY_VIDEOPROCAMP_BRIGHTNESS);
+                }
+
+                // EVComp
+                if (m_mediaCapture.VideoDeviceController.ExposureCompensationControl.Supported)
+                {
+                    m_evCompController = m_controlManager.CreateController(DefaultControlHelper.DefaultControllerType.ExtendedCameraControl, (uint)CameraKsPropertyHelper.ExtendedControlKind.KSPROPERTY_CAMERACONTROL_EXTENDED_EVCOMPENSATION);
+                }
+
+                // Blur
+                bool isBlurControlSupported = false;
+                IExtendedPropertyPayload getPayload = null;
+
+                getPayload = PropertyInquiry.GetExtendedControl(m_mediaCapture.VideoDeviceController, ExtendedControlKind.KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION);
+                isBlurControlSupported = (getPayload != null);
+                if (isBlurControlSupported && (((ulong)BackgroundSegmentationCapabilityKind.KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR & ~getPayload.Capability) == 0))
+                {
+                    m_backgroundBlurController = m_controlManager.CreateController(DefaultControlHelper.DefaultControllerType.ExtendedCameraControl, (uint)ExtendedControlKind.KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION);
+                }
+
+                // Updating UI elements
+                await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+                {
+                    try
                     {
-                        DefaultEVCompSlider.Value = m_mediaCapture.VideoDeviceController.ExposureCompensationControl.Value;
-                    }
-                    DefaultEVCompSlider.ValueChanged += DefaultEVCompSlider_ValueChanged;
-                }
+                        // The sliders is initialized to work with the values that driver provides as supported range and step
+                        if (m_contrastController != null)
+                        {
+                            DefaultContrastSlider.ValueChanged -= DefaultContrastSlider_ValueChanged;
+                            DefaultContrastSlider.Minimum = m_mediaCapture.VideoDeviceController.Contrast.Capabilities.Min;
+                            DefaultContrastSlider.Maximum = m_mediaCapture.VideoDeviceController.Contrast.Capabilities.Max;
+                            DefaultContrastSlider.StepFrequency = m_mediaCapture.VideoDeviceController.Contrast.Capabilities.Step;
+                            DefaultContrastSlider.Visibility = Visibility.Visible;
+                            if (m_contrastController.HasDefaultValueStored())
+                            {
+                                DefaultContrastSlider.Value = m_contrastController.DefaultValue;
+                            }
+                            else
+                            {
+                                double value = 0;
+                                if (m_mediaCapture.VideoDeviceController.Contrast.TryGetValue(out value))
+                                {
+                                    DefaultContrastSlider.Value = value;
+                                }
+                                else
+                                {
+                                    DefaultContrastSlider.IsEnabled = false;
+                                }
+                            }
+                            DefaultContrastSlider.ValueChanged += DefaultContrastSlider_ValueChanged;
+                        }
 
-                if (m_backgroundBlurController != null)
-                {
-                    DefaultBlurToggle.Toggled -= DefaultBlurToggle_Toggled;
-                    DefaultBlurToggle.Visibility = Visibility.Visible;
-                    DefaultBlurToggle.IsOn = m_backgroundBlurController.DefaultValue != 0;
-                    DefaultBlurToggle.Toggled += DefaultBlurToggle_Toggled;
-                }
-            });
+                        if (m_brightnessController != null)
+                        {
+                            DefaultBrightnessSlider.ValueChanged -= DefaultBrightnessSlider_ValueChanged;
+                            DefaultBrightnessSlider.Minimum = m_mediaCapture.VideoDeviceController.Brightness.Capabilities.Min;
+                            DefaultBrightnessSlider.Maximum = m_mediaCapture.VideoDeviceController.Brightness.Capabilities.Max;
+                            DefaultBrightnessSlider.StepFrequency = m_mediaCapture.VideoDeviceController.Brightness.Capabilities.Step;
+                            DefaultBrightnessSlider.Visibility = Visibility.Visible;
+                            if (m_brightnessController.HasDefaultValueStored())
+                            {
+                                DefaultBrightnessSlider.Value = m_brightnessController.DefaultValue;
+                            }
+                            else
+                            {
+                                double value = 0;
+                                if (m_mediaCapture.VideoDeviceController.Contrast.TryGetValue(out value))
+                                {
+                                    DefaultBrightnessSlider.Value = value;
+                                }
+                                else
+                                {
+                                    DefaultBrightnessSlider.IsEnabled = false;
+                                }
+                            }
+                            DefaultBrightnessSlider.ValueChanged += DefaultBrightnessSlider_ValueChanged;
+                        }
+                        if (m_evCompController != null)
+                        {
+                            DefaultEVCompSlider.ValueChanged -= DefaultEVCompSlider_ValueChanged;
+                            DefaultEVCompSlider.Minimum = m_mediaCapture.VideoDeviceController.ExposureCompensationControl.Min;
+                            DefaultEVCompSlider.Maximum = m_mediaCapture.VideoDeviceController.ExposureCompensationControl.Max;
+                            DefaultEVCompSlider.StepFrequency = m_mediaCapture.VideoDeviceController.ExposureCompensationControl.Step;
+                            DefaultEVCompSlider.Visibility = Visibility.Visible;
+                            if (m_evCompController.HasDefaultValueStored())
+                            {
+                                DefaultEVCompSlider.Value = m_evCompController.DefaultValue;
+                            }
+                            else
+                            {
+                                DefaultEVCompSlider.Value = m_mediaCapture.VideoDeviceController.ExposureCompensationControl.Value;
+                            }
+                            DefaultEVCompSlider.ValueChanged += DefaultEVCompSlider_ValueChanged;
+                        }
+
+                        if (m_backgroundBlurController != null)
+                        {
+                            DefaultBlurToggle.Toggled -= DefaultBlurToggle_Toggled;
+                            DefaultBlurToggle.Visibility = Visibility.Visible;
+                            if (m_backgroundBlurController.HasDefaultValueStored())
+                            {
+                                DefaultBlurToggle.IsOn = (m_backgroundBlurController.DefaultValue != 0);
+                            }
+                            else
+                            {
+                                // if the flag value is set to BackgroundSegmentationCapabilityKind.KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR
+                                DefaultBlurToggle.IsOn = (getPayload.Flags % 2 == 1); ;
+                            }
+                            DefaultBlurToggle.IsOn = m_backgroundBlurController.DefaultValue != 0;
+                            DefaultBlurToggle.Toggled += DefaultBlurToggle_Toggled;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        UITextOutput.Text = $"error: {ex.Message}";
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                UITextOutput.Text = $"error: {ex.Message}";
+            }
         }
 
         private void DefaultContrastSlider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
         {
-            m_contrastController.DefaultValue = (uint)e.NewValue;
-            m_mediaCapture.VideoDeviceController.Contrast.TrySetValue(e.NewValue);
+            try
+            {
+                m_contrastController.DefaultValue = (int)e.NewValue;
+                m_mediaCapture.VideoDeviceController.Contrast.TrySetValue(e.NewValue);
+            }
+            catch (Exception ex)
+            {
+                UITextOutput.Text = $"error: {ex.Message}";
+            }
         }
 
         private void DefaultBrightnessSlider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
         {
-            m_brightnessController.DefaultValue = (uint)e.NewValue;
-            m_mediaCapture.VideoDeviceController.Brightness.TrySetValue(e.NewValue);
+            try
+            {
+                m_brightnessController.DefaultValue = (int)e.NewValue;
+                m_mediaCapture.VideoDeviceController.Brightness.TrySetValue(e.NewValue);
+            }
+            catch (Exception ex)
+            {
+                UITextOutput.Text = $"error: {ex.Message}";
+            }
         }
 
         private void DefaultBlurToggle_Toggled(object sender, RoutedEventArgs e)
         {
-            uint flags = (DefaultBlurToggle.IsOn == true) ? (uint)BackgroundSegmentationCapabilityKind.KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR : (uint)BackgroundSegmentationCapabilityKind.KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_OFF;
-            m_backgroundBlurController.DefaultValue = flags;
-            PropertyInquiry.SetExtendedControlFlags(m_mediaCapture.VideoDeviceController, ExtendedControlKind.KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION, flags);
+            try
+            {
+                int flags = (int)((DefaultBlurToggle.IsOn == true) ? BackgroundSegmentationCapabilityKind.KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR : BackgroundSegmentationCapabilityKind.KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_OFF);
+                m_backgroundBlurController.DefaultValue = flags;
+                PropertyInquiry.SetExtendedControlFlags(m_mediaCapture.VideoDeviceController, ExtendedControlKind.KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION, (uint)flags);
+            }
+            catch (Exception ex)
+            {
+                UITextOutput.Text = $"error: {ex.Message}";
+            }
         }
 
         private async void DefaultEVCompSlider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
         {
-            m_evCompController.DefaultValue = (uint)e.NewValue;
-            await m_mediaCapture.VideoDeviceController.ExposureCompensationControl.SetValueAsync((float)e.NewValue);
+            try
+            {
+                m_evCompController.DefaultValue = (int)e.NewValue;
+                await m_mediaCapture.VideoDeviceController.ExposureCompensationControl.SetValueAsync((float)e.NewValue);
+            }
+            catch (Exception ex)
+            {
+                UITextOutput.Text = $"error: {ex.Message}";
+            }
         }
     }
 }

--- a/Samples/CameraSettingsExternalSettingsApp/readme.md
+++ b/Samples/CameraSettingsExternalSettingsApp/readme.md
@@ -20,7 +20,7 @@ e.g., `Get-AppxPackage -Name *ExternalCamera*`
 
 Adding this information will create a button to launch the application from the camera configuration page in the Settings (Settings -> Bluetooth & devices -> Cameras -> \<camera name\> ). If the app is not installed it will try to search it from the Store.
 
-**NOTE:** Disable/enable of the camera and restart of the machine might be needed that the new app association is properly configured.
+**NOTE:** Uninstall and reinstall of the camera device and restart of the machine might be needed to edit or remove properly the associated configuration app.
 
 ## Sample functionality
  The app will initialize the given camera, start preview, and show the following controls (if camera implements them) that will set current value and save it as the default value by using [IMFCameraConfigurationManager](https://docs.microsoft.com/windows/win32/api/mfidl/nn-mfidl-imfcameraconfigurationmanager) functionality.


### PR DESCRIPTION
1. fixing issues with the sample 
    - the switch case in DerfaultControlHelper.cpp DefaultController::DefaultController() was not instantiating the correct type of controller if passing DefaultControllerType::CameraControl v.s. DefaultControllerType::ExtendedCameraControl
    - UI was missing text labels 

2. Adding support for controlling default value of EVCompensation to expose something on devices that do not support brightness nor contrast nor blur such as mipi cameras on ARM64..