### PR TITLE
Fix for EVComp values saved as default.

### DIFF
--- a/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/MainPage.xaml.cs
+++ b/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/MainPage.xaml.cs
@@ -293,7 +293,9 @@ namespace OutboundSettingsAppTest
         {
             try
             {
-                m_evCompController.DefaultValue = (int)e.NewValue;
+                // For KSPROPERTY_CAMERACONTROL_EXTENDED_EVCOMPENSATION the floating point values need to be scaled
+                // to matching int range with the step size.
+                m_evCompController.DefaultValue = (int) Math.Round(e.NewValue / DefaultEVCompSlider.StepFrequency);
                 await m_mediaCapture.VideoDeviceController.ExposureCompensationControl.SetValueAsync((float)e.NewValue);
             }
             catch (Exception ex)


### PR DESCRIPTION
 ExposureCompensationControl and KSPROPERTY_CAMERACONTROL_EXTENDED_EVCOMPENSATION uses different scale, so we need to scale the value from ExposureCompensationControl with the step size to get correct integer representation.