### PR TITLE
Fixed Network Media Streamer build after updating to SDK 22000 (and VS2022)

### DIFF
--- a/Samples/NetworkMediaStreamer/CameraRTPStreamerApp/CameraRTPStreamerApp.cpp
+++ b/Samples/NetworkMediaStreamer/CameraRTPStreamerApp/CameraRTPStreamerApp.cpp
@@ -12,6 +12,7 @@
 #include <windows.media.core.interop.h>
 #include <windows.foundation.h>
 #include <windows.Storage.streams.h>
+#include <EventToken.h>
 #include <winrt\base.h>
 #include <winrt\Windows.Media.Capture.h>
 #include <winrt\Windows.Media.Capture.Frames.h>
@@ -22,7 +23,7 @@
 #include <winrt\Windows.Media.MediaProperties.h>
 #include <winrt\Windows.Networking.Connectivity.h>
 #include <winrt\Windows.storage.streams.h>
-
+#include <winrt\windows.foundation.collections.h>
 #include "..\Common\inc\NetworkMediaStreamer.h"
 #include "..\Common\inc\RTPMediaStreamer.h"
 #include "..\Common\inc\RTSPServerControl.h"
@@ -330,12 +331,18 @@ int main()
             });
         for (int i = 0; i < (int)LoggerType::LOGGER_MAX; i++)
         {
-            EventRegistrationToken t1, t2;
+            ::EventRegistrationToken t1, t2;
             winrt::check_hresult(serverHandle->AddLogHandler((LoggerType)i, loggerdelegate.as<ABI::LogHandler>().get(), &t1));
-            serverHandleSecure ? winrt::check_hresult(serverHandleSecure->AddLogHandler((LoggerType)i, loggerdelegate.as<ABI::LogHandler>().get(), &t2)) : void(0);
+            if (serverHandleSecure)
+            {
+                winrt::check_hresult(serverHandleSecure->AddLogHandler((LoggerType)i, loggerdelegate.as<ABI::LogHandler>().get(), &t2));
+            }
         }
         winrt::check_hresult(serverHandle->StartServer());
-        serverHandleSecure ? winrt::check_hresult(serverHandleSecure->StartServer()) : void(0);
+        if (serverHandleSecure)
+        {
+            winrt::check_hresult(serverHandleSecure->StartServer());
+        }
 #ifdef USE_FR
         auto fsources = mc.FrameSources();
         MediaFrameSource selectedFs(nullptr);

--- a/Samples/NetworkMediaStreamer/CameraRTPStreamerApp/build/CameraRTPStreamerApp.vcxproj
+++ b/Samples/NetworkMediaStreamer/CameraRTPStreamerApp/build/CameraRTPStreamerApp.vcxproj
@@ -23,33 +23,33 @@
     <ProjectGuid>{61D9C2A4-F52D-44DF-A262-7C5C8E7BB850}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>VideoStreamerApp</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
     <ProjectName>CameraRTPStreamerApp</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Samples/NetworkMediaStreamer/Common/inc/NetworkMediaStreamer.h
+++ b/Samples/NetworkMediaStreamer/Common/inc/NetworkMediaStreamer.h
@@ -25,22 +25,21 @@ namespace ABI
     template<> MIDL_INTERFACE("7E37DD5F-7749-46E4-856A-FE098BAA142D") IEventHandler<IBuffer*> : IEventHandler_impl<IBuffer*>{};
     typedef IEventHandler<IBuffer*> PacketHandler;
 }
+namespace winrt {
 
-namespace winrt 
-{
     typedef winrt::Windows::Foundation::EventHandler<winrt::Windows::Storage::Streams::IBuffer> PacketHandler;
-    template <> struct winrt::impl::guid_storage<PacketHandler>
-    {
-        static constexpr guid value{ __uuidof(ABI::PacketHandler) };
-    };
 }
+
+template <> struct winrt::impl::category<winrt::PacketHandler> { using type = winrt::impl::delegate_category; };
+template <> inline constexpr winrt::guid winrt::impl::guid_v<winrt::PacketHandler> {__uuidof(ABI::PacketHandler)};
+
 
 //EXTERN_C const IID IID_IVideoStreamer;
 MIDL_INTERFACE("022C6CB9-64D5-472F-8753-76382CC5F4DA")
 INetworkMediaStreamSink : public IMFStreamSink
 {
 public:
-    virtual STDMETHODIMP AddTransportHandler(ABI::PacketHandler * pPackethandler, LPCWSTR pProtocol = L"rtp", LPCWSTR pParam = L"") = 0;
+    virtual STDMETHODIMP AddTransportHandler (ABI::PacketHandler* pPackethandler, LPCWSTR pProtocol = L"rtp", LPCWSTR pParam = L"") = 0;
     virtual STDMETHODIMP RemoveTransportHandler(ABI::PacketHandler* pPacketHandler) = 0;
     virtual STDMETHODIMP AddNetworkClient(LPCWSTR pDestination, LPCWSTR pProtocol = L"rtp", LPCWSTR pParams = L"") = 0;
     virtual STDMETHODIMP RemoveNetworkClient(LPCWSTR pDestination) = 0;

--- a/Samples/NetworkMediaStreamer/Common/inc/RTSPServerControl.h
+++ b/Samples/NetworkMediaStreamer/Common/inc/RTSPServerControl.h
@@ -28,9 +28,8 @@ enum class SessionStatus : int32_t
     SessionPaused,
     SessionEnded
 };
-
 template <> struct winrt::impl::category<SessionStatus> { using type = winrt::impl::enum_category; };
-template <> struct winrt::impl::name<SessionStatus> { static constexpr auto& value{ L"SessionStatus" }; };
+template <> inline constexpr winrt::guid winrt::impl::guid_v <SessionStatus> {0xD3266732, 0x337F, 0x48A7, { 0xB4,0x0B,0x4F,0xDC,0xA2,0xA1,0xC6,0x95 } };
 
 enum class LoggerType
 {
@@ -52,7 +51,7 @@ enum class AuthType
 MIDL_INTERFACE("BC710897-4727-4154-B085-52C5F5A4047C")
 IRTSPAuthProvider : public ::IUnknown
 {
-    virtual STDMETHODIMP GetNewAuthSessionMessage(HSTRING * pAuthSessionMessage) = 0;
+    virtual STDMETHODIMP GetNewAuthSessionMessage(HSTRING* pAuthSessionMessage) = 0;
     virtual STDMETHODIMP Authorize(LPCWSTR pAuthResp, LPCWSTR pAuthSesMsg, LPCWSTR pMethod) = 0;
 };
 
@@ -80,17 +79,7 @@ namespace winrt
 {
     typedef winrt::Windows::Foundation::TypedEventHandler<uintptr_t, SessionStatus> SessionStatusHandler;
 
-    template <> struct winrt::impl::guid_storage<SessionStatusHandler>
-    {
-        static constexpr guid value{ __uuidof(ABI::SessionStatusHandler) };
-    };
-
     typedef winrt::Windows::Foundation::TypedEventHandler <winrt::hresult, winrt::hstring> LogHandler;
-
-    template <> struct winrt::impl::guid_storage<LogHandler>
-    {
-        static constexpr guid value{ __uuidof(ABI::LogHandler) };
-    };
 
     typedef winrt::Windows::Foundation::Collections::PropertySet RTSPSuffixSinkMap;
 }

--- a/Samples/NetworkMediaStreamer/NetworkMediaStreamerBase/build/NetworkMediaStreamer.vcxproj
+++ b/Samples/NetworkMediaStreamer/NetworkMediaStreamerBase/build/NetworkMediaStreamer.vcxproj
@@ -23,33 +23,33 @@
     <ProjectGuid>{58E4848E-B347-43FB-94C1-C5C85ABFD6B0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>VideoStreamer</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
     <ProjectName>NetworkMediaStreamer</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Samples/NetworkMediaStreamer/RTPMediaStreamer/build/RTPMediaStreamer.vcxproj
+++ b/Samples/NetworkMediaStreamer/RTPMediaStreamer/build/RTPMediaStreamer.vcxproj
@@ -37,33 +37,33 @@
     <ProjectGuid>{763269FF-37EB-4A0A-B152-0924CFA81FFF}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>VideoStreamer</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
     <ProjectName>RTPMediaStreamer</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Samples/NetworkMediaStreamer/RTPMediaStreamer/inc/pch.h
+++ b/Samples/NetworkMediaStreamer/RTPMediaStreamer/inc/pch.h
@@ -5,6 +5,7 @@
 #include <mferror.h>
 #include <ws2tcpip.h>
 #include <mfidl.h>
+#include<mutex>
 #include <windows.foundation.h>
 #include <windows.Storage.streams.h>
 #include <winrt\base.h>

--- a/Samples/NetworkMediaStreamer/RTSPServer/build/RTSPServer.vcxproj
+++ b/Samples/NetworkMediaStreamer/RTSPServer/build/RTSPServer.vcxproj
@@ -41,33 +41,33 @@
     <ProjectGuid>{1F92CAD2-33C6-42ED-AF2E-FDD0D8CE07BC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>VideoStreamer</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
     <ProjectName>RTSPServer</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Samples/NetworkMediaStreamer/Readme.md
+++ b/Samples/NetworkMediaStreamer/Readme.md
@@ -13,7 +13,10 @@ The NetworkMediaStreamer is a set of basic implementations of RTP streaming and 
 
 ![NetworkStreamer Block Diagram](docs/RTSPVideoStreamer.jpg)  
  In the above figure, the red arrows denote Media data flow and the black arrows denote command and control flow.
- 
+
+## Build Setup
+  The code has been built and tested with VS2022, SDK version 22000
+
  ## RTPSink
  The RTP streaming is implemented as a COM class which implements [IMFMediaSink](https://docs.microsoft.com/en-us/windows/win32/api/mfidl/nn-mfidl-imfmediasink). This class encapsulates the Network media stream sink which does the actual packetization work and UDP streaming. The NetworkMediaStream sink can be controlled via two interfaces:
  1. [IMFStreamSink](https://docs.microsoft.com/en-us/windows/win32/api/mfidl/nn-mfidl-imfstreamsink)


### PR DESCRIPTION
Fixed Network Media Streamer build after updating to SDK 22000 (and VS2022)

This code emulates winrt/cpp type metadata, to work around using idl files and related compile tools. 
Updating to SDK 22000 causes emulated winrt/cpp type metadata to break the build as the constructs have changed in the new version.
This PR fixes those issues for SDK 22000
