### PR TITLE
Rework and update the Companion app sample showing how to use IMFCameraConfigurationManager and IMFCameraControlDefaultsCollection.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,11 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/Generated Files/
+Samples/ControlMonitorApp/ControlMonitorHelper/Generated Files/
+Samples/ExtendedControlAndMetadata/EyeGazeAndBackgroundSegmentation/CameraKsPropertyHelper/Generated Files/
+Samples/ExtendedControlAndMetadata/MediaCaptureSampleExtendedControl/Generated Files/
+Samples/Shared/CameraKsPropertyHelper/Generated Files/
+Samples/VirtualCamera/VirtualCameraManager_WinRT/Generated Files/
+Samples/ExtendedControlAndMetadata/CPP-CLI_MediaCaptureSampleExtendedControl/Generated Files/
+Samples/ExtendedControlAndMetadata/WinRT_ExtendedControlAndMetadataSample/CameraKsPropertyHelper/Generated Files/

--- a/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.cpp
+++ b/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.cpp
@@ -27,9 +27,9 @@ namespace winrt::DefaultControlHelper::implementation
         }
     }
 
-    wil::com_ptr_t<IMFCameraControlDefaultsCollection> DefaultControlManager::GetDefaultCollection()
+    wil::com_ptr<IMFCameraControlDefaultsCollection> DefaultControlManager::GetDefaultCollection()
     {
-        wil::com_ptr_t<IMFCameraControlDefaultsCollection> spControlDefaultsCollection = nullptr;
+        wil::com_ptr<IMFCameraControlDefaultsCollection> spControlDefaultsCollection = nullptr;
         THROW_IF_FAILED(m_spConfigManager->LoadDefaults(m_spAttributes.get(), &spControlDefaultsCollection));
         return spControlDefaultsCollection;
     }
@@ -89,7 +89,7 @@ namespace winrt::DefaultControlHelper::implementation
         }
     };
 
-    winrt::Windows::Foundation::IReference<int32_t> DefaultController::TryGetDefaultValueStored()
+    winrt::Windows::Foundation::IReference<int32_t> DefaultController::TryGetStoredDefaultValue()
     {
         winrt::Windows::Foundation::IReference<int32_t> resultValue = nullptr;
         bool hasDefaultValueStored = false;

--- a/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.cpp
+++ b/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.cpp
@@ -13,13 +13,25 @@ namespace winrt::DefaultControlHelper::implementation
 
     DefaultControlManager::DefaultControlManager(winrt::hstring cameraSymbolicLink)
     {
-        m_configManager = wil::CoCreateInstance<IMFCameraConfigurationManager>(CLSID_CameraConfigurationManager);
+        m_spConfigManager = wil::CoCreateInstance<IMFCameraConfigurationManager>(CLSID_CameraConfigurationManager);
+        THROW_IF_FAILED(MFCreateAttributes(&m_spAttributes, 1));
+        THROW_IF_FAILED(m_spAttributes->SetString(MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK, cameraSymbolicLink.c_str()));
+    }
 
-        wil::com_ptr<IMFAttributes> attributes;
-        THROW_IF_FAILED(MFCreateAttributes(&attributes, 1));
-        THROW_IF_FAILED(attributes->SetString(MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK, cameraSymbolicLink.c_str()));
+    DefaultControlManager::~DefaultControlManager()
+    {
+        if (m_spConfigManager != nullptr)
+        {
+            m_spConfigManager->Shutdown();
+            m_spConfigManager = nullptr;
+        }
+    }
 
-        THROW_IF_FAILED(m_configManager->LoadDefaults(attributes.get(), &m_controlDefaultsCollection));
+    wil::com_ptr_t<IMFCameraControlDefaultsCollection> DefaultControlManager::GetDefaultCollection()
+    {
+        wil::com_ptr_t<IMFCameraControlDefaultsCollection> spControlDefaultsCollection = nullptr;
+        THROW_IF_FAILED(m_spConfigManager->LoadDefaults(m_spAttributes.get(), &spControlDefaultsCollection));
+        return spControlDefaultsCollection;
     }
 
     winrt::DefaultControlHelper::DefaultController DefaultControlManager::CreateController(DefaultControllerType type, uint32_t id)
@@ -27,16 +39,20 @@ namespace winrt::DefaultControlHelper::implementation
         return winrt::make<DefaultController>(type, id, get_strong());
     }
 
-    HRESULT DefaultControlManager::Save()
+    HRESULT DefaultControlManager::SaveDefaultCollection(IMFCameraControlDefaultsCollection* defaultCollection)
     {
-        return m_configManager->SaveDefaults(m_controlDefaultsCollection.get());
+        THROW_HR_IF_NULL(E_INVALIDARG, defaultCollection);
+        return m_spConfigManager->SaveDefaults(defaultCollection);
     }
 
 #pragma endregion
 
 #pragma region DefaultController
 
-    DefaultController::DefaultController(winrt::DefaultControlHelper::DefaultControllerType type, const uint32_t id, winrt::com_ptr<DefaultControlManager> manager)
+    DefaultController::DefaultController(
+        winrt::DefaultControlHelper::DefaultControllerType type, 
+        const uint32_t id, 
+        winrt::com_ptr<DefaultControlManager> manager)
     {
         m_id = id;
         m_controlManager = manager;
@@ -44,42 +60,48 @@ namespace winrt::DefaultControlHelper::implementation
         // Creating an underlying helper controller based on the asked control type
         switch (type)
         {
-        case winrt::DefaultControlHelper::DefaultControllerType::VideoProcAmp:
-            m_internalController = std::make_unique< DefaultControllerVidCapVideoProcAmp>();
-            m_setGuid = PROPSETID_VIDCAP_VIDEOPROCAMP;
-            break;
+            case winrt::DefaultControlHelper::DefaultControllerType::VideoProcAmp:
+                m_internalController = std::make_unique<DefaultControllerVidCapVideoProcAmp>();
+                m_setGuid = PROPSETID_VIDCAP_VIDEOPROCAMP;
+                break;
         
-        case winrt::DefaultControlHelper::DefaultControllerType::CameraControl:
-            m_internalController = std::make_unique<DefaultControllerVidCapVideoProcAmp>();
-            m_setGuid = PROPSETID_VIDCAP_CAMERACONTROL;
-            break;
+            case winrt::DefaultControlHelper::DefaultControllerType::CameraControl:
+                m_internalController = std::make_unique<DefaultControllerVidCapVideoProcAmp>();
+                m_setGuid = PROPSETID_VIDCAP_CAMERACONTROL;
+                break;
         
-        case winrt::DefaultControlHelper::DefaultControllerType::ExtendedCameraControl:
-            m_setGuid = KSPROPERTYSETID_ExtendedCameraControl;
-            switch (id)
-            {
-                case KSPROPERTY_CAMERACONTROL_EXTENDED_EVCOMPENSATION:
-                    m_internalController = std::make_unique<DefaultControllerEVCompExtendedControl>();
-                    break;
+            case winrt::DefaultControlHelper::DefaultControllerType::ExtendedCameraControl:
+                m_setGuid = KSPROPERTYSETID_ExtendedCameraControl;
+                switch (id)
+                {
+                    case KSPROPERTY_CAMERACONTROL_EXTENDED_EVCOMPENSATION:
+                        m_internalController = std::make_unique<DefaultControllerEVCompExtendedControl>();
+                        break;
 
-                default: 
-                    m_internalController = std::make_unique<DefaultControllerExtendedControl>();
-                    break;
-            }
-            
-            break;
-        default:
-            break;
+                    default: 
+                        m_internalController = std::make_unique<DefaultControllerExtendedControl>();
+                        break;
+                }
+                break;
+
+            default:
+                break;
         }
+    };
+
+    winrt::Windows::Foundation::IReference<int32_t> DefaultController::TryGetDefaultValueStored()
+    {
+        winrt::Windows::Foundation::IReference<int32_t> resultValue = nullptr;
+        bool hasDefaultValueStored = false;
 
         // check if there is an existing entry for this control to store a default value
-        auto collection = m_controlManager.get()->GetCollection();
+        auto collection = m_controlManager->GetDefaultCollection();
         auto count = collection->GetControlCount();
-        
+
         if (count > 0)
         {
             wil::com_ptr<IMFCameraControlDefaults> existingControlDefaults;
-            for (ULONG i = 0; i < count && !m_hasDefaultValueStored; i++)
+            for (ULONG i = 0; i < count && !hasDefaultValueStored; i++)
             {
                 byte* pProperty = nullptr;
                 ULONG cbProperty = 0;
@@ -87,7 +109,11 @@ namespace winrt::DefaultControlHelper::implementation
                 ULONG cbData = 0;
 
                 collection->GetControl(i, &existingControlDefaults);
-                THROW_IF_FAILED(existingControlDefaults->LockControlData((void**)&pProperty, &cbProperty, (void**)&pControlHeader, &cbData));
+                THROW_IF_FAILED(existingControlDefaults->LockControlData(
+                    (void**)&pProperty,
+                    &cbProperty,
+                    (void**)&pControlHeader,
+                    &cbData));
 
                 // we assume we get a KSProperty at the very least
                 if (cbProperty < sizeof(KSPROPERTY))
@@ -97,65 +123,22 @@ namespace winrt::DefaultControlHelper::implementation
                 THROW_IF_NULL_ALLOC(pProperty);
                 KSPROPERTY* pKsProperty = (KSPROPERTY*)pProperty;
 
-                if (pKsProperty->Id == id && IsEqualGUID(pKsProperty->Set, m_setGuid))
+                // if we find a KSProperty payload matching ID and PropertySet storing a default value..
+                if (pKsProperty->Id == m_id && IsEqualGUID(pKsProperty->Set, m_setGuid))
                 {
-                    m_hasDefaultValueStored = true;
+                    resultValue = winrt::Windows::Foundation::IReference<int>(
+                        m_internalController->GetValueFromPayload(
+                            (void*)pProperty,
+                            cbProperty,
+                            (void*)pControlHeader,
+                            cbData));
+
+                    hasDefaultValueStored = true;
                 }
-                THROW_IF_FAILED(existingControlDefaults->UnlockControlData());
-            }
-        }
-    };
-
-    int32_t DefaultController::DefaultValue()
-    {
-        int32_t resultValue = INT32_MAX;
-        if (m_hasDefaultValueStored)
-        {
-            m_internalController->Initialize(m_controlManager, m_controlDefaults, m_setGuid, m_id);
-            try
-            {
-                void* pControl = nullptr;
-                ULONG cbControl = 0;
-                void* pData = nullptr;
-                ULONG cbData = 0;
-
-                THROW_IF_FAILED(m_controlDefaults->LockControlData(&pControl, &cbControl, &pData, &cbData));
+                HRESULT hr = (existingControlDefaults->UnlockControlData());
+                if (FAILED(hr))
                 {
-                    THROW_IF_NULL_ALLOC(pControl);
-                    THROW_IF_NULL_ALLOC(pData);
-                    auto unlock = wil::scope_exit([&]()
-                        {
-                            // The Unlock call can fail if there's no existing configuration or the required flags/capabilities
-                            // are otherwise wrong or unset.
-                            THROW_IF_FAILED(m_controlDefaults->UnlockControlData());
-                        });
-
-                    resultValue = m_internalController->GetStoredDefaultValue((void*)pControl, cbControl, (void*)pData, cbData);
-
-                    // Getting range info if available
-                    MF_CAMERA_CONTROL_RANGE_INFO rangeInfo = {};
-
-                    try
-                    {
-                        THROW_IF_FAILED(m_controlDefaults->GetRangeInfo(&rangeInfo));
-                        m_rangeInfo.emplace(rangeInfo);
-                    }
-                    catch (const wil::ResultException& e)
-                    {
-                        // GetRangeInfo will return MF_E_NOT_FOUND if the control does
-                        // not support range information.
-                        if (e.GetErrorCode() != MF_E_NOT_FOUND)
-                        {
-                            THROW_EXCEPTION(e);
-                        }
-                    }
-                }
-            }
-            catch (...)
-            {
-                if (m_rangeInfo.has_value())
-                {
-                    resultValue = m_rangeInfo->defaultValue;
+                    assert(hr != S_OK);
                 }
             }
         }
@@ -163,18 +146,18 @@ namespace winrt::DefaultControlHelper::implementation
         return resultValue;
     }
 
-    void DefaultController::DefaultValue(int32_t const& value)
+    void DefaultController::SetDefaultValue(int32_t const& value)
     {
         void* pControl = nullptr;
         ULONG cbControl = 0;
         void* pData = nullptr;
         ULONG cbData = 0;
 
-        auto collection = m_controlManager->GetCollection();
+        auto collection = m_controlManager->GetDefaultCollection();
 
-        m_internalController->Initialize(m_controlManager, m_controlDefaults, m_setGuid, m_id);
+        auto defaults = m_internalController->GetOrAddDefaultToCollection(collection.get(), m_setGuid, m_id);
 
-        THROW_IF_FAILED(m_controlDefaults->LockControlData(&pControl, &cbControl, &pData, &cbData));
+        THROW_IF_FAILED(defaults->LockControlData(&pControl, &cbControl, &pData, &cbData));
         {
             THROW_IF_NULL_ALLOC(pControl);
             THROW_IF_NULL_ALLOC(pData);
@@ -182,35 +165,42 @@ namespace winrt::DefaultControlHelper::implementation
                 {
                     // The Unlock call can fail if there's no existing configuration or the required flags/capabilities
                     // are otherwise wrong or unset.
-                    THROW_IF_FAILED(m_controlDefaults->UnlockControlData());
+                    THROW_IF_FAILED(defaults->UnlockControlData());
                 });
-            m_internalController->SaveDefault((void*)pControl, cbControl, (void*)pData, cbData, value);
+            m_internalController->FormatPayloadWithValue((void*)pControl, cbControl, (void*)pData, cbData, value);
         }
-        THROW_IF_FAILED(m_controlManager->Save());
-        m_hasDefaultValueStored = true;
+
+        THROW_IF_FAILED(m_controlManager->SaveDefaultCollection(collection.get()));
     }
 
 #pragma endregion
-
-    void DefaultControllerVidCapVideoProcAmp::Initialize(winrt::com_ptr<DefaultControlManager> manager, wil::com_ptr<IMFCameraControlDefaults>& defaults, winrt::guid setGuid, uint32_t id)
+    
+    wil::com_ptr<IMFCameraControlDefaults> DefaultControllerVidCapVideoProcAmp::GetOrAddDefaultToCollection(
+        IMFCameraControlDefaultsCollection* defaultCollection, 
+        winrt::guid setGuid, 
+        uint32_t id)
     {
-        auto collection = manager->GetCollection();
+        wil::com_ptr<IMFCameraControlDefaults> spDefaults = nullptr;
+        
+        THROW_HR_IF_NULL(E_INVALIDARG, defaultCollection);
 
-        THROW_IF_FAILED(collection->GetOrAddControl(
+        THROW_IF_FAILED(defaultCollection->GetOrAddControl(
             MF_CAMERA_CONTROL_CONFIGURATION_TYPE_POSTSTART,
             setGuid,
             id,
             sizeof(KSPROPERTY_VIDEOPROCAMP_S),
             sizeof(KSPROPERTY_VIDEOPROCAMP_S),
-            &defaults));
+            &spDefaults));
+
+        return spDefaults;
     }
 
-    void DefaultControllerVidCapVideoProcAmp::SaveDefault(void* pControl, ULONG controlSize, void* pData, ULONG dataSize, int32_t const& value)
+    void DefaultControllerVidCapVideoProcAmp::FormatPayloadWithValue(void* pControl, ULONG controlSize, void* pPayload, ULONG payloadSize, int32_t const& value)
     {
         THROW_HR_IF(E_UNEXPECTED, controlSize < sizeof(KSPROPERTY_VIDEOPROCAMP_S));
-        THROW_HR_IF(E_UNEXPECTED, dataSize < sizeof(KSPROPERTY_VIDEOPROCAMP_S));
+        THROW_HR_IF(E_UNEXPECTED, payloadSize < sizeof(KSPROPERTY_VIDEOPROCAMP_S));
         KSPROPERTY_VIDEOPROCAMP_S* pVidCapControl = (KSPROPERTY_VIDEOPROCAMP_S*)pControl;
-        KSPROPERTY_VIDEOPROCAMP_S* pVidCapData = (KSPROPERTY_VIDEOPROCAMP_S*)pData;
+        KSPROPERTY_VIDEOPROCAMP_S* pVidCapData = (KSPROPERTY_VIDEOPROCAMP_S*)pPayload;
 
         pVidCapControl->Flags = KSPROPERTY_VIDEOPROCAMP_FLAGS_MANUAL;
         pVidCapControl->Property.Flags = KSPROPERTY_TYPE_SET;
@@ -224,7 +214,7 @@ namespace winrt::DefaultControlHelper::implementation
         pVidCapData->Flags = pVidCapControl->Flags;
     }
 
-    int32_t DefaultControllerVidCapVideoProcAmp::GetStoredDefaultValue(void* pControl, ULONG controlSize, void*, ULONG)
+    int32_t DefaultControllerVidCapVideoProcAmp::GetValueFromPayload(void* pControl, ULONG controlSize, void*, ULONG)
     {
         THROW_HR_IF(E_UNEXPECTED, controlSize < sizeof(KSPROPERTY_VIDEOPROCAMP_S));
         KSPROPERTY_VIDEOPROCAMP_S* pVidCapControl = (KSPROPERTY_VIDEOPROCAMP_S*)pControl;
@@ -232,56 +222,78 @@ namespace winrt::DefaultControlHelper::implementation
         return pVidCapControl->Value;
     }
 
-    void DefaultControllerExtendedControl::Initialize(winrt::com_ptr<DefaultControlManager> manager, wil::com_ptr<IMFCameraControlDefaults>& defaults, winrt::guid, uint32_t id)
+    wil::com_ptr<IMFCameraControlDefaults> DefaultControllerExtendedControl::GetOrAddDefaultToCollection(
+        IMFCameraControlDefaultsCollection* defaultCollection,
+        winrt::guid setGuid,
+        uint32_t id)
     {
-        auto collection = manager->GetCollection();
+        // we are not using this parameter since we exercise the API tailored for extended property GetOrAddExtendedControl()
+        UNREFERENCED_PARAMETER(setGuid); 
 
-        THROW_IF_FAILED(collection->GetOrAddExtendedControl(
+        wil::com_ptr<IMFCameraControlDefaults> spDefaults = nullptr;
+
+        THROW_HR_IF_NULL(E_INVALIDARG, defaultCollection);
+
+        THROW_IF_FAILED(defaultCollection->GetOrAddExtendedControl(
             MF_CAMERA_CONTROL_CONFIGURATION_TYPE_POSTSTART,
             id,
             KSCAMERA_EXTENDEDPROP_FILTERSCOPE,
             sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_VALUE),
-            &defaults));
+            &spDefaults));
+
+        return spDefaults;
     }
 
-    void DefaultControllerExtendedControl::SaveDefault(void* pControl, ULONG controlSize, void* pData, ULONG dataSize, int32_t const& value)
+    void DefaultControllerExtendedControl::FormatPayloadWithValue(void* pControl, ULONG controlSize, void* pPayload, ULONG payloadSize, int32_t const& value)
     {
         THROW_HR_IF(E_UNEXPECTED, controlSize < sizeof(KSPROPERTY));
-        THROW_HR_IF(E_UNEXPECTED, dataSize < sizeof(KSCAMERA_EXTENDEDPROP_HEADER));
+        THROW_HR_IF(E_UNEXPECTED, payloadSize < sizeof(KSCAMERA_EXTENDEDPROP_HEADER));
         KSPROPERTY* pProperty = (KSPROPERTY*)pControl;
-        KSCAMERA_EXTENDEDPROP_HEADER* pExtendedHeader = (KSCAMERA_EXTENDEDPROP_HEADER*)pData;
+        KSCAMERA_EXTENDEDPROP_HEADER* pExtendedHeader = (KSCAMERA_EXTENDEDPROP_HEADER*)pPayload;
+        KSCAMERA_EXTENDEDPROP_VALUE* pExtendedValue = (KSCAMERA_EXTENDEDPROP_VALUE*)(pExtendedHeader+1);
+        *pExtendedValue = {};
 
         pProperty->Flags = KSPROPERTY_TYPE_SET;
         pExtendedHeader->Flags = value;
     }
 
-    int32_t DefaultControllerExtendedControl::GetStoredDefaultValue(void*, ULONG, void* pData, ULONG dataSize)
+    int32_t DefaultControllerExtendedControl::GetValueFromPayload(void*, ULONG, void* pPayload, ULONG payloadSize)
     {
-        THROW_HR_IF(E_UNEXPECTED, dataSize < sizeof(KSCAMERA_EXTENDEDPROP_HEADER));
-        KSCAMERA_EXTENDEDPROP_HEADER* pExtendedHeader = (KSCAMERA_EXTENDEDPROP_HEADER*)pData;
+        THROW_HR_IF(E_UNEXPECTED, payloadSize < sizeof(KSCAMERA_EXTENDEDPROP_HEADER));
+        KSCAMERA_EXTENDEDPROP_HEADER* pExtendedHeader = (KSCAMERA_EXTENDEDPROP_HEADER*)pPayload;
 
         return (int32_t)pExtendedHeader->Flags;
     }
 
-    void DefaultControllerEVCompExtendedControl::Initialize(winrt::com_ptr<DefaultControlManager> manager, wil::com_ptr<IMFCameraControlDefaults>& defaults, winrt::guid, uint32_t id)
+    wil::com_ptr<IMFCameraControlDefaults> DefaultControllerEVCompExtendedControl::GetOrAddDefaultToCollection(
+        IMFCameraControlDefaultsCollection* defaultCollection,
+        winrt::guid setGuid,
+        uint32_t id)
     {
-        auto collection = manager->GetCollection();
+        // we are not using this parameter since we exercise the API tailored for extended property GetOrAddExtendedControl()
+        UNREFERENCED_PARAMETER(setGuid);
 
-        THROW_IF_FAILED(collection->GetOrAddExtendedControl(
+        wil::com_ptr<IMFCameraControlDefaults> spDefaults = nullptr;
+
+        THROW_HR_IF_NULL(E_INVALIDARG, defaultCollection);
+
+        THROW_IF_FAILED(defaultCollection->GetOrAddExtendedControl(
             MF_CAMERA_CONTROL_CONFIGURATION_TYPE_POSTSTART,
             id,
             KSCAMERA_EXTENDEDPROP_FILTERSCOPE,
             sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_EVCOMPENSATION),
-            &defaults));
+            &spDefaults));
+
+        return spDefaults;
     }
 
-    void DefaultControllerEVCompExtendedControl::SaveDefault(void* pControl, ULONG controlSize, void* pData, ULONG dataSize, int32_t const& value)
+    void DefaultControllerEVCompExtendedControl::FormatPayloadWithValue(void* pControl, ULONG controlSize, void* pPayload, ULONG payloadSize, int32_t const& value)
     {
         THROW_HR_IF(E_UNEXPECTED, controlSize < sizeof(KSPROPERTY));
-        THROW_HR_IF(E_UNEXPECTED, dataSize < (sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_EVCOMPENSATION)));
+        THROW_HR_IF(E_UNEXPECTED, payloadSize < (sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_EVCOMPENSATION)));
         KSPROPERTY* pProperty = (KSPROPERTY*)pControl;
-        KSCAMERA_EXTENDEDPROP_HEADER* pExtendedHeader = (KSCAMERA_EXTENDEDPROP_HEADER*)pData;
-        KSCAMERA_EXTENDEDPROP_EVCOMPENSATION* evCompExtPropPayload = (KSCAMERA_EXTENDEDPROP_EVCOMPENSATION*)((PBYTE)pData + sizeof(KSCAMERA_EXTENDEDPROP_HEADER));;
+        KSCAMERA_EXTENDEDPROP_HEADER* pExtendedHeader = (KSCAMERA_EXTENDEDPROP_HEADER*)pPayload;
+        KSCAMERA_EXTENDEDPROP_EVCOMPENSATION* evCompExtPropPayload = (KSCAMERA_EXTENDEDPROP_EVCOMPENSATION*)(pExtendedHeader + 1);
 
         pProperty->Flags = KSPROPERTY_TYPE_SET;
         pExtendedHeader->Flags = 0;
@@ -293,10 +305,10 @@ namespace winrt::DefaultControlHelper::implementation
         evCompExtPropPayload->Mode = 0;
     }
 
-    int32_t DefaultControllerEVCompExtendedControl::GetStoredDefaultValue(void*, ULONG, void* pData, ULONG dataSize)
+    int32_t DefaultControllerEVCompExtendedControl::GetValueFromPayload(void*, ULONG, void* pPayload, ULONG payloadSize)
     {
-        THROW_HR_IF(E_UNEXPECTED, dataSize < (sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_EVCOMPENSATION)));
-        KSCAMERA_EXTENDEDPROP_EVCOMPENSATION* evCompExtPropPayload = (KSCAMERA_EXTENDEDPROP_EVCOMPENSATION*)((PBYTE)pData + sizeof(KSCAMERA_EXTENDEDPROP_HEADER));;
+        THROW_HR_IF(E_UNEXPECTED, payloadSize < (sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_EVCOMPENSATION)));
+        KSCAMERA_EXTENDEDPROP_EVCOMPENSATION* evCompExtPropPayload = (KSCAMERA_EXTENDEDPROP_EVCOMPENSATION*)((PBYTE)pPayload + sizeof(KSCAMERA_EXTENDEDPROP_HEADER));;
 
         return evCompExtPropPayload->Value;
     }

--- a/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.h
+++ b/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.h
@@ -19,20 +19,20 @@ namespace winrt::DefaultControlHelper::implementation
 
         winrt::DefaultControlHelper::DefaultController CreateController(DefaultControllerType type, const uint32_t id);
 
-        wil::com_ptr_t<IMFCameraControlDefaultsCollection> GetDefaultCollection();
+        wil::com_ptr<IMFCameraControlDefaultsCollection> GetDefaultCollection();
 
         HRESULT SaveDefaultCollection(IMFCameraControlDefaultsCollection* collection);
 
     private:
 
-        wil::com_ptr_t<IMFCameraConfigurationManager> m_spConfigManager;
+        wil::com_ptr<IMFCameraConfigurationManager> m_spConfigManager;
         wil::com_ptr<IMFAttributes> m_spAttributes;
     };
 
     struct DefaultController : DefaultControllerT<DefaultController>
     {
         DefaultController(winrt::DefaultControlHelper::DefaultControllerType type, uint32_t id, winrt::com_ptr<DefaultControlManager> manager);
-        winrt::Windows::Foundation::IReference<int32_t> TryGetDefaultValueStored();
+        winrt::Windows::Foundation::IReference<int32_t> TryGetStoredDefaultValue();
         void SetDefaultValue(int32_t const& value);
 
     private:

--- a/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.idl
+++ b/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.idl
@@ -15,7 +15,7 @@ namespace DefaultControlHelper
     
     runtimeclass DefaultController
     {
-        Windows.Foundation.IReference<Int32> TryGetDefaultValueStored();
+        Windows.Foundation.IReference<Int32> TryGetStoredDefaultValue();
         void SetDefaultValue(Int32 value);
     }
 

--- a/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.idl
+++ b/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.idl
@@ -15,8 +15,8 @@ namespace DefaultControlHelper
     
     runtimeclass DefaultController
     {
-        Boolean HasDefaultValueStored();
-        Int32 DefaultValue;
+        Windows.Foundation.IReference<Int32> TryGetDefaultValueStored();
+        void SetDefaultValue(Int32 value);
     }
 
     [default_interface]

--- a/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.vcxproj
+++ b/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/DefaultControlHelper.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -150,15 +150,15 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220201.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220201.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-    <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220201.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220201.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/packages.config
+++ b/Samples/CameraSettingsExternalSettingsApp/DefaultControlHelper/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220608.4" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220201.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240122.1" targetFramework="native" />
 </packages>

--- a/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample.sln
+++ b/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CameraKsPropertyHelper", "..\Shared\CameraKsPropertyHelper\CameraKsPropertyHelper.vcxproj", "{3E174357-0294-40F1-BA11-7330617DDBB5}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ControlMonitorHelperWinRT", "..\ControlMonitorApp\ControlMonitorHelper\ControlMonitorHelperWinRT.vcxproj", "{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
@@ -82,6 +84,22 @@ Global
 		{3E174357-0294-40F1-BA11-7330617DDBB5}.Release|x64.Build.0 = Release|x64
 		{3E174357-0294-40F1-BA11-7330617DDBB5}.Release|x86.ActiveCfg = Release|Win32
 		{3E174357-0294-40F1-BA11-7330617DDBB5}.Release|x86.Build.0 = Release|Win32
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Debug|ARM.ActiveCfg = Debug|x64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Debug|ARM.Build.0 = Debug|x64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Debug|ARM64.Build.0 = Debug|ARM64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Debug|x64.ActiveCfg = Debug|x64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Debug|x64.Build.0 = Debug|x64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Debug|x86.ActiveCfg = Debug|x64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Debug|x86.Build.0 = Debug|x64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Release|ARM.ActiveCfg = Release|x64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Release|ARM.Build.0 = Release|x64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Release|ARM64.ActiveCfg = Release|ARM64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Release|ARM64.Build.0 = Release|ARM64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Release|x64.ActiveCfg = Release|x64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Release|x64.Build.0 = Release|x64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Release|x86.ActiveCfg = Release|x64
+		{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}.Release|x86.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/ExternalCameraSettingsAppSample.csproj
+++ b/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/ExternalCameraSettingsAppSample.csproj
@@ -23,8 +23,8 @@
     <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
     <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
-    <AppxBundle>Always</AppxBundle>
-    <AppxBundlePlatforms>x86|x64|arm|arm64</AppxBundlePlatforms>
+    <AppxBundle>Never</AppxBundle>
+    <AppxBundlePlatforms>arm64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
@@ -159,10 +159,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.12</Version>
+      <Version>6.2.14</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\ControlMonitorApp\ControlMonitorHelper\ControlMonitorHelperWinRT.vcxproj">
+      <Project>{5a835b38-9b32-43ce-90fa-edc3e4fc8070}</Project>
+      <Name>ControlMonitorHelperWinRT</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Shared\CameraKsPropertyHelper\CameraKsPropertyHelper.vcxproj">
       <Project>{3e174357-0294-40f1-ba11-7330617ddbb5}</Project>
       <Name>CameraKsPropertyHelper</Name>
@@ -176,6 +180,9 @@
     <PRIResource Include="Resources.resw">
       <SubType>Designer</SubType>
     </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="ExternalCameraSettingsAppSample_TemporaryKey.pfx" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/MainPage.xaml
+++ b/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/MainPage.xaml
@@ -9,75 +9,26 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid>
+    <ScrollViewer ScrollViewer.VerticalScrollBarVisibility="Visible" VerticalScrollMode="Enabled">
         <StackPanel>
-            <TextBlock x:Name="SelectedCameraTB"/>
-            <MediaPlayerElement x:Name="UIMediaPlayerElement" AreTransportControlsEnabled="False"/>
-            <TextBox x:Name="UITextOutput" TextWrapping="Wrap"/>
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10" HorizontalAlignment="Center">
-                <TextBlock
-                    x:Uid="DefaultContrast"
-                    Text="Contrast"
-                    Visibility="{Binding ElementName=DefaultContrastSlider, Path=Visibility}"
-                    VerticalAlignment="Center" />
-                <Slider 
-                    x:Name="DefaultContrastSlider"
-                    x:Uid="DefaultContrastSlider"
-                    AutomationProperties.LabeledBy="{Binding ElementName=DefaultContrast}"
-                    Minimum="0"
-                    Maximum="100"
-                    StepFrequency="1"
-                    ValueChanged="DefaultContrastSlider_ValueChanged"
-                    HorizontalAlignment="Center"
-                    MaxWidth="300"
-                    MinWidth="200"
-                    Visibility="Collapsed"
-                    VerticalAlignment="Center"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10" HorizontalAlignment="Center">
-                <TextBlock
-                    x:Uid="DefaultBrightness"
-                    Text="Brightness"
-                    Visibility="{Binding ElementName=DefaultBrightnessSlider, Path=Visibility}"
-                    VerticalAlignment="Center" />
-                <Slider 
-                    x:Name="DefaultBrightnessSlider"
-                    x:Uid="DefaultBrightnessSlider"
-                    AutomationProperties.LabeledBy="{Binding ElementName=DefaultBrightness}"
-                    Minimum="0"
-                    Maximum="100"
-                    StepFrequency="1"
-                    ValueChanged="DefaultBrightnessSlider_ValueChanged"
-                    HorizontalAlignment="Center"
-                    MaxWidth="300"
-                    MinWidth="200"
-                    Visibility="Collapsed"
-                    VerticalAlignment="Center"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10" HorizontalAlignment="Center">
-                <TextBlock
-                    x:Uid="DefaultBlur"
-                    Text="Blur"
-                    Visibility="{Binding ElementName=DefaultBlurToggle, Path=Visibility}"
-                    VerticalAlignment="Center" />
-                <ToggleSwitch 
-                    x:Name="DefaultBlurToggle"
-                    x:Uid="DefaultBlurToggle"
-                    AutomationProperties.LabeledBy="{Binding ElementName=DefaultBlur}"
-                    Toggled="DefaultBlurToggle_Toggled"
-                    HorizontalAlignment="Center"
-                    MaxWidth="300"
-                    MinWidth="200"
-                    Visibility="Collapsed"
-                    VerticalAlignment="Center"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10" HorizontalAlignment="Center">
-                <TextBlock
+        <StackPanel>
+            <TextBlock Text="Camera ID:"/>
+            <ListBox x:Name="UICameraSelectionList" SelectionMode="Single" SelectionChanged="UICameraSelectionList_SelectionChanged"/>
+            <TextBlock x:Name="SelectedCameraTB" IsTextSelectionEnabled="True"/>
+            <Button x:Name="UILaunchSettingsButton" Content="Launch Camera Settings" Visibility="Collapsed" Click="UILaunchSettingsButton_Click"/>
+            <TextBlock x:Name="UITextOutput" TextWrapping="Wrap" IsTextSelectionEnabled="True"/>
+        </StackPanel>
+
+            <StackPanel>
+                <MediaPlayerElement x:Name="UIMediaPlayerElement" AreTransportControlsEnabled="False" MaxHeight="400" MaxWidth="400"/>
+
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10" HorizontalAlignment="Center">
+                    <TextBlock
                     x:Uid="DefaultEVComp"
                     Text="EVCompensation"
                     Visibility="{Binding ElementName=DefaultEVCompSlider, Path=Visibility}"
                     VerticalAlignment="Center" />
-                <Slider 
+                    <Slider 
                     x:Name="DefaultEVCompSlider"
                     x:Uid="DefaultEVCompSlider"
                     AutomationProperties.LabeledBy="{Binding ElementName=DefaultEVComp}"
@@ -90,9 +41,70 @@
                     MinWidth="200"
                     Visibility="Collapsed"
                     VerticalAlignment="Center"/>
-            </StackPanel>
-            
-        </StackPanel>
+                </StackPanel>
 
-    </Grid>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10" HorizontalAlignment="Center">
+                    <TextBlock
+                    x:Uid="DefaultBrightness"
+                    Text="Brightness"
+                    Visibility="{Binding ElementName=DefaultBrightnessSlider, Path=Visibility}"
+                    VerticalAlignment="Center" />
+                    <Slider 
+                    x:Name="DefaultBrightnessSlider"
+                    x:Uid="DefaultBrightnessSlider"
+                    AutomationProperties.LabeledBy="{Binding ElementName=DefaultBrightness}"
+                    Minimum="0"
+                    Maximum="100"
+                    StepFrequency="1"
+                    ValueChanged="DefaultBrightnessSlider_ValueChanged"
+                    HorizontalAlignment="Center"
+                    MaxWidth="300"
+                    MinWidth="200"
+                    Visibility="Collapsed"
+                    VerticalAlignment="Center"/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10" HorizontalAlignment="Center">
+                    <TextBlock
+                    x:Uid="DefaultContrast"
+                    Text="Contrast"
+                    Visibility="{Binding ElementName=DefaultContrastSlider, Path=Visibility}"
+                    VerticalAlignment="Center" />
+                    <Slider 
+                    x:Name="DefaultContrastSlider"
+                    x:Uid="DefaultContrastSlider"
+                    AutomationProperties.LabeledBy="{Binding ElementName=DefaultContrast}"
+                    Minimum="0"
+                    Maximum="100"
+                    StepFrequency="1"
+                    ValueChanged="DefaultContrastSlider_ValueChanged"
+                    HorizontalAlignment="Center"
+                    MaxWidth="300"
+                    MinWidth="200"
+                    Visibility="Collapsed"
+                    VerticalAlignment="Center"/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10" HorizontalAlignment="Center">
+                    <TextBlock
+                    x:Uid="DefaultBlur"
+                    Text="Blur"
+                    Visibility="{Binding ElementName=DefaultBlurToggle, Path=Visibility}"
+                    VerticalAlignment="Center" />
+                    <ToggleSwitch 
+                    x:Name="DefaultBlurToggle"
+                    x:Uid="DefaultBlurToggle"
+                    AutomationProperties.LabeledBy="{Binding ElementName=DefaultBlur}"
+                    Toggled="DefaultBlurToggle_Toggled"
+                    HorizontalAlignment="Center"
+                    MaxWidth="300"
+                    MinWidth="200"
+                    Visibility="Collapsed"
+                    VerticalAlignment="Center"/>
+                </StackPanel>
+
+            </StackPanel>
+
+        </StackPanel>
+    </ScrollViewer>
 </Page>

--- a/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/MainPage.xaml.cs
+++ b/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/MainPage.xaml.cs
@@ -188,8 +188,7 @@ namespace OutboundSettingsAppTest
                 m_mediaCapture = new MediaCapture();
                 m_mediaPlayer = new MediaPlayer();
 
-                // We initialize the MediaCapture instance with the virtual camera in sharing mode
-                // to preview its stream without blocking other app from using it
+                // We initialize the MediaCapture instance with the provided camera ID
                 var initSettings = new MediaCaptureInitializationSettings()
                 {
                     SharingMode = MediaCaptureSharingMode.ExclusiveControl,

--- a/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/MainPage.xaml.cs
+++ b/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/MainPage.xaml.cs
@@ -365,7 +365,7 @@ namespace OutboundSettingsAppTest
 
                         DefaultBlurToggle.Toggled -= DefaultBlurToggle_Toggled;
                         DefaultBlurToggle.Visibility = Visibility.Visible;
-                        var defaultValue = m_backgroundBlurController.TryGetDefaultValueStored();
+                        var defaultValue = m_backgroundBlurController.TryGetStoredDefaultValue();
                         if(defaultValue != null)
                         {
                             DefaultBlurToggle.IsOn = (defaultValue != 0);
@@ -399,7 +399,7 @@ namespace OutboundSettingsAppTest
                         DefaultEVCompSlider.Maximum = m_mediaCapture.VideoDeviceController.ExposureCompensationControl.Max;
                         DefaultEVCompSlider.StepFrequency = m_mediaCapture.VideoDeviceController.ExposureCompensationControl.Step;
                         DefaultEVCompSlider.Visibility = Visibility.Visible;
-                        var defaultValue = m_evCompController.TryGetDefaultValueStored();
+                        var defaultValue = m_evCompController.TryGetStoredDefaultValue();
                         if (defaultValue != null)
                         {
                             DefaultEVCompSlider.Value = (double)defaultValue;
@@ -438,7 +438,7 @@ namespace OutboundSettingsAppTest
                         DefaultBrightnessSlider.StepFrequency = m_mediaCapture.VideoDeviceController.Brightness.Capabilities.Step;
                         DefaultBrightnessSlider.Visibility = Visibility.Visible;
 
-                        var defaultValue = m_brightnessController.TryGetDefaultValueStored();
+                        var defaultValue = m_brightnessController.TryGetStoredDefaultValue();
                         if (defaultValue != null)
                         {
                             DefaultBrightnessSlider.Value = (double)defaultValue;
@@ -484,7 +484,7 @@ namespace OutboundSettingsAppTest
                         DefaultContrastSlider.StepFrequency = m_mediaCapture.VideoDeviceController.Contrast.Capabilities.Step;
                         DefaultContrastSlider.Visibility = Visibility.Visible;
 
-                        var defaultValue = m_contrastController.TryGetDefaultValueStored();
+                        var defaultValue = m_contrastController.TryGetStoredDefaultValue();
                         if (defaultValue != null)
                         {
                             DefaultContrastSlider.Value = (double)defaultValue;

--- a/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/Package.appxmanifest
+++ b/Samples/CameraSettingsExternalSettingsApp/ExternalCameraSettingsAppSample/Package.appxmanifest
@@ -8,8 +8,8 @@
 
   <Identity
     Name="ExternalCameraSettingsAppSample"
-    Publisher="CN=Contoso"
-    Version="1.0.0.0" />
+    Publisher="CN=lOUIS"
+    Version="1.0.2.0" />
 
   <mp:PhoneIdentity PhoneProductId="a46e3123-db2e-46f0-aeed-cb05a0c9d384" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/Samples/CameraSettingsExternalSettingsApp/readme.md
+++ b/Samples/CameraSettingsExternalSettingsApp/readme.md
@@ -1,16 +1,39 @@
 # ExternalCameraSettingsApp Sample
 
-This sample app will demonstrate how to build an external camera settings app associated to a camera device. This app allows to adjust control in real time as well as set a control value as the default one to be applied every time the associated camera is started. The association between app and camera device is typically done by the camera driver at installation time (i.e. by a camera manufacturer wanting to offer an app tie-in to their physical device or a virtual camera implemented offering an app such as [the ***VirtualCameraManager_App*** in our other sample](..\VirtualCamera\README.md)). This settings app would then be launchable directly from the associated camera device settings page *(Windows Settings &rarr; Bluetooth & devices &rarr; Cameras &rarr; \<the associated camera\> in the "Related settings" section)*
+This sample app will demonstrate how to build an external camera settings app (also known as a "companion app") associated to a camera device. This app allows to adjust control in real time as well as set a control value as the default one to be applied every time the associated camera is started. The association between app and camera device is typically done by the camera driver at installation time (i.e. by a camera manufacturer wanting to offer an app tie-in to their physical device or a virtual camera implemented offering an app such as [the ***VirtualCameraManager_App*** in our other sample](..\VirtualCamera\README.md)). This settings app would then be launchable directly from the associated camera device settings page *(Windows Settings &rarr; Bluetooth & devices &rarr; Cameras &rarr; \<the associated camera\> in the "Related settings" section at the bottom)*
+
+This sample also registers a callback for when a user changes the default value for a control it displays, such as when using the Windows Settings page of the target camera concurrently to this sample, so that it can refresh its UI to show the default value now stored. See the [IMFCameraControlMonitor sample](..\ControlMonitorApp\readme.md) for more detail on this mechanism.
 
 This app will use camera symbolic link(symlink) name that's provided via [Application.OnLaunched](https://docs.microsoft.com/uwp/api/windows.ui.xaml.application.onlaunched?view=winrt-22000) arguments and typically passed further on to the [Page.OnNavigatedTo](https://docs.microsoft.com/uwp/api/windows.ui.xaml.controls.page.onnavigatedto?view=winrt-22000). The camera symlink is only passed to the app launch when the app is registered to be an additional Settings app for the specific camera.
 
 ## Requirements
 This sample is built using Visual Studio 2019 and requires [Windows SDK version 22621](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/).
 
-## Registering the app with Camera Settings
+## Registering the companion app with the target camera so that it can be launched from Windows Settings page
 As external camera settings apps are typically companion apps for the specific camera, this registering process is normally done by driver inf or MSOS descriptor in FW that will add the registry entry.
 
-The application's package family name (PFN) need to be added to the device interface node in the registry: `HKLM\SYSTEM\CurrentControlSet\Control\DeviceClasses\{e5323777-f976-4f5b-9b55-b94699c46e44}\<camera symlink>\#GLOBAL\Device Parameters`
+**example excerpt showing how to declare a companion app in a .inf:**
+~~~
+[ContosoAvs.NT.Interfaces]
+AddInterface = %KSCATEGORY_VIDEO_CAMERA%, "%Cam.RefGuid%", Cam.CaptureInterface.NT,
+AddInterface = %KSCATEGORY_CAPTURE%, "%Cam.RefGuid%", Cam.CaptureInterface.NT,
+AddInterface = %KSCATEGORY_VIDEO%, "%Cam.RefGuid%", Cam.CaptureInterface.NT,
+
+[Cam.CaptureInterface.NT]
+AddReg=ContosoAvs.Reg.Cam
+
+[ContosoAvs.Reg.Cam]
+HKR,,"SCSVCamPfn",,%YOUR_APP_PFN%
+
+[Strings]
+YOUR_APP_PFN="ExternalCameraSettingsAppSample_kd1fqbpx9e9ng"
+Cam.RefGuid="{CF65BE8C-5F60-4C39-A2E7-504A365E6BD6}"
+KSCATEGORY_VIDEO_CAMERA="{E5323777-F976-4F5B-9B55-B94699C46E44}"
+KSCATEGORY_CAPTURE="{65E8773D-8F56-11D0-A3B9-00A0C9223196}"
+KSCATEGORY_VIDEO="{6994AD05-93EF-11D0-A3CC-00A0C9223196}"
+~~~
+
+You can also specify it for now by editing the registry. The application's package family name (PFN) need to be added to the device interface node in the registry under: `HKLM\SYSTEM\CurrentControlSet\Control\DeviceClasses\{e5323777-f976-4f5b-9b55-b94699c46e44}\<camera symlink>\#GLOBAL\Device Parameters`
 | Name | Type | Data |
 |------|------|------|
 | SCSVCamPfn | REG_SZ| \<PFN\> |
@@ -27,5 +50,6 @@ Adding this information will create a button to launch the application from the 
   - Contrast control slider
   - Brightness control slider
   - Background segmentation toggle for Blur on/off
+  - Exposure Compensation Value control slider
 
 **NOTE:** For default value configurations the sample uses MF_CAMERA_CONTROL_CONFIGURATION_TYPE_POSTSTART but some controls might require MF_CAMERA_CONTROL_CONFIGURATION_TYPE_PRESTART. These requirements come from the DDI definitions of that control.

--- a/Samples/ControlMonitorApp/ControlMonitorHelper/ControlMonitorHelperWinRT.vcxproj
+++ b/Samples/ControlMonitorApp/ControlMonitorHelper/ControlMonitorHelperWinRT.vcxproj
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\WindowsStudio\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\WindowsStudio\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
   <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.220131.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.220131.2\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
-    <ProjectGuid>{3ac253a5-a383-49d8-acc0-102c1e46e42f}</ProjectGuid>
+    <ProjectGuid>{5A835B38-9B32-43CE-90FA-EDC3E4FC8070}</ProjectGuid>
     <ProjectName>ControlMonitorHelperWinRT</ProjectName>
     <RootNamespace>ControlMonitorHelperWinRT</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
@@ -115,7 +116,7 @@
     <Midl Include="ControlMonitorHelperWinRT.idl" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="ControlMonitorHelper_WinRT.def" />
+    <None Include="ControlMonitorHelperWinRT.def" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -123,15 +124,15 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.220131.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.220131.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)\packages\Microsoft.Windows.ImplementationLibrary.1.0.220201.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.ImplementationLibrary.1.0.220201.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="..\..\WindowsStudio\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\WindowsStudio\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="..\..\WindowsStudio\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\WindowsStudio\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.220131.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.220131.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.220131.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.220131.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.ImplementationLibrary.1.0.220201.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.ImplementationLibrary.1.0.220201.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('..\..\WindowsStudio\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\WindowsStudio\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('..\..\WindowsStudio\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\WindowsStudio\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\..\WindowsStudio\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\WindowsStudio\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
 </Project>

--- a/Samples/ControlMonitorApp/ControlMonitorHelper/ControlMonitorHelperWinRT.vcxproj.filters
+++ b/Samples/ControlMonitorApp/ControlMonitorHelper/ControlMonitorHelperWinRT.vcxproj.filters
@@ -12,12 +12,14 @@
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="ControlMonitorHelper.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
+    <ClInclude Include="ControlMonitorHelper.h" />
   </ItemGroup>
   <ItemGroup>
-    <Midl Include="ControlMonitorHelper.idl" />
+    <Midl Include="ControlMonitorHelperWinRT.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ControlMonitorHelperWinRT.def" />

--- a/Samples/ControlMonitorApp/ControlMonitorHelper/packages.config
+++ b/Samples/ControlMonitorApp/ControlMonitorHelper/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220131.2" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220201.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240122.1" targetFramework="native" />
 </packages>

--- a/Samples/Shared/CameraKsPropertyHelper/CameraKsPropertyHelper.vcxproj
+++ b/Samples/Shared/CameraKsPropertyHelper/CameraKsPropertyHelper.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -166,15 +166,15 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220201.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220201.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-    <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220201.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220201.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220608.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/Samples/Shared/CameraKsPropertyHelper/packages.config
+++ b/Samples/Shared/CameraKsPropertyHelper/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220608.4" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220201.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240122.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Rework and update the Companion app sample showing how to use IMFCameraConfigurationManager and IMFCameraControlDefaultsCollection.

- remove quirks on the helper WinRTComponent project, fetching the collection everytime there is a need to know if there is a value stored or when a value needs to be stored.
- added IMFCameraControlMonitor to refresh UI if Windows Settings page is used concurrently to the sample
- added a UI to help get the camera ID if the sample is launched without any parameters
- handle sample app lifecycle minimize/maximize
- update readme, adding .inf excerpt to show how to set companion app PFN from there