### PR TITLE
Add Windows Studio Effect DDI doc and code sample features to cover profiles and MediaType

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,30 +5,45 @@
 
 # Windows Platform sample applications and tools for using and developing the Camera features
 
-This repo contains sample applications that demonstrate the API usage patterns for using the camera related features on Universal Windows Platform (UWP), Win32 Desktop platform and .NetCore 3.0 for Windows 10. 
-These code samples were created with the project templates available in Visual Studio, and are designed to run on desktop, mobile, and future devices.
+This repo contains a collection of samples that demonstrate the API usage patterns for using the camera related features in WinUI3, .Net, Universal Windows Platform (UWP) and Win32 Desktop applications for Windows 10 and Windows 11.
 
 > **Note:** If you are unfamiliar with Git and GitHub, you can download the entire collection as a 
 > [ZIP file](https://github.com/microsoft/Windows-Camera/archive/master.zip), but be 
 > sure to unzip everything to access shared dependencies. 
 
-## Universal Windows Platform (UWP) samples/tools
+## Content
 
-These samples require Visual Studio 2017 Update 4 or higher and the Windows Software Development Kit (SDK) version 16299 for Windows 10 or higher on a per-sample basis.
+- [Windows Studio Effects (*WSE*) camera sample application - C# .Net WinUI & WinRT](Samples/WindowsStudio/README.md)
 
-   [Get a free copy of Visual Studio 2017 Community Edition with support for building Universal Windows Platform apps](http://go.microsoft.com/fwlink/p/?LinkID=280676)
+- [Windows Studio Effects Driver-Defined Interfaces *(DDI)* documentation with C++ win32 code snippets](Samples/WindowsStudio/Windows%20Studio%20Effects%20DDIs.md)
+
+- [Sample of Control Monitoring app that listens changes to various camera controls](Samples/ControlMonitorApp/readme.md)
+
+- [Sample of Virtual Camera mediasource (IMFVirtualCamera) and configuration app](Samples/VirtualCamera/README.md)
+
+- [Sample of Companion Settings app to read and save default configurations via IMFCameraConfigurationManager APIs](Samples/CameraSettingsExternalSettingsApp/readme.md)
+
+- [Sample to demonstrate how to use the IMFSensorActivityMonitor API](Samples/SensorActivityMonitorConsoleApp/readme.md)
+
+- [Sample to demonstrate basic camera application with MediaCapture APIs and WinUI3](Samples/MediaCaptureWinUI3/MediaCaptureWinUI3/Readme.md)
+
+- [Win32 Desktop console application demonstrating use of WinRT Windows Media Capture APIs](Samples/WMCConsole_winrtcpp/README.md)
+
+- [WinRT applications demonstrating use of custom KS Camera Extended Properties and extraction of frame metadata](Samples/ExtendedControlAndMetadata/README.md)
+
+- [Win32 Desktop application and libraries demonstrating use of Windows APIs and Windows Media Foundation APIs for RTP/RTSP streaming from camera](Samples/NetworkMediaStreamer/Readme.md)
+
+- [360-degree camera capture/record/preview](Tools/Cam360/README.md)
+
+## Visual Studio requirement
+
+These samples require Visual Studio and the Windows Software Development Kit (SDK) of varying minimal version for Windows 10 or higher on a per-sample basis.
+
+   [Get a free copy of Visual Studio Community Edition](https://visualstudio.microsoft.com/)
 
 Additionally, to stay on top of the latest updates to Windows and the development tools, become a Windows Insider by joining the Windows Insider Program.
 
    [Become a Windows Insider](https://insider.windows.com/)
-
-## Win32 Desktop applications/tools
-
-These samples require Visual Studio 2017 Update 4 or higher and the Windows Software Development Kit (SDK) version 17763 for Windows 10.
-
-## .NetCore 3.0 Desktop applications/tools
-
-These samples require .NetCore 3.0 SDK and Visual Studio 2019 preview. (https://visualstudio.microsoft.com/vs/preview/)
 
 ## Using the samples
 
@@ -62,44 +77,3 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 
-## Samples
-<table>
- <tr>
-  <td><a href="Tools/Cam360">360-degree camera capture/record/preview</a></td>
- </tr>
-</table>
-<table>
- <tr>
-  <td><a href="Samples/WMCConsole_winrtcpp">Win32 Desktop console application demonstrating use of Windows Media Capture APIs</a></td>
- </tr>
-</table>
-<table>
- <tr>
-  <td><a href="Samples/ExtendedControlAndMetadata">WinRT applications demonstrating use of custom KS Camera Extended Properties and extraction of frame metadata</a></td>
- </tr>
-</table>
-<table>
- <tr>
-  <td><a href="Samples/NetworkMediaStreamer"> Win32 Desktop application and libraries demonstrating use of Windows APIs and Windows Media Foundation APIs for RTP/RTSP streaming from camera</a></td>
- </tr>
-</table>
-<table>
- <tr>
-  <td><a href="Samples/VirtualCamera"> Sample of Virtual Camera mediasource and configuration app </a></td>
- </tr>
-</table>
-<table>
- <tr>
-  <td><a href="Samples/CameraSettingsExternalSettingsApp"> Sample of Companion Settings app to read and save default configurations via IMFCameraConfigurationManager APIs</a></td>
- </tr>
-</table>
-<table>
- <tr>
-  <td><a href="Samples/ControlMonitorApp">Sample of Control Monitoring app that listens changes to various camera controls</a></td>
- </tr>
-</table>
-<table>
- <tr>
-  <td><a href="Samples/WindowsStudio">C# .Net WinUI & WinRT sample application for using a Windows Studio camera and its set of effects via APIs</a></td>
- </tr>
-</table>

--- a/Samples/ControlMonitorApp/ControlMonitorHelper/ControlMonitorHelper.cpp
+++ b/Samples/ControlMonitorApp/ControlMonitorHelper/ControlMonitorHelper.cpp
@@ -68,34 +68,10 @@ namespace winrt::ControlMonitorHelperWinRT::implementation
     {
         if (m_spMonitor != nullptr)
         {
-            THROW_IF_FAILED(m_spMonitor->Stop());
-            for each (auto&& var in m_controls)
+            if (m_isStarted)
             {
-                if (var.controlKind != ControlKind::All)
-                {
-                    GUID guid{};
-                    switch (var.controlKind)
-                    {
-                    case ControlKind::VidCapCameraControlKind:
-                        guid = PROPSETID_VIDCAP_CAMERACONTROL;
-                        break;
-                    case ControlKind::VidCapVideoProcAmpKind:
-                        guid = PROPSETID_VIDCAP_VIDEOPROCAMP;
-                        break;
-                    case ControlKind::ExtendedControlKind:
-                        guid = KSPROPERTYSETID_ExtendedCameraControl;
-                        break;
-                    case ControlKind::WindowsStudioEffectsKind:
-                        guid = KSPROPERTYSETID_WindowsCameraEffect;
-                        break;
-                    default:
-                        throw winrt::hresult_error(E_UNEXPECTED, L"Invalid ControlKind");
-                    }
-
-                    THROW_IF_FAILED(m_spMonitor->RemoveControlSubscription(guid, var.controlId));
-                }
+                THROW_IF_FAILED(m_spMonitor->Stop());
             }
-
             m_spMonitor = nullptr;
         }
     } CATCH_LOG()
@@ -107,6 +83,7 @@ namespace winrt::ControlMonitorHelperWinRT::implementation
         {
             throw winrt::hresult_error(hr, L"could not Stop IMFCameraControlMonitor..");
         }
+        m_isStarted = false;
     }
 
     void ControlMonitorManager::Start()
@@ -116,6 +93,7 @@ namespace winrt::ControlMonitorHelperWinRT::implementation
         {
             throw winrt::hresult_error(hr, L"could not Start IMFCameraControlMonitor..");
         }
+        m_isStarted = true;
     }
 
     //

--- a/Samples/ControlMonitorApp/ControlMonitorHelper/ControlMonitorHelper.h
+++ b/Samples/ControlMonitorApp/ControlMonitorHelper/ControlMonitorHelper.h
@@ -54,6 +54,7 @@ namespace winrt::ControlMonitorHelperWinRT::implementation
         winrt::com_ptr<CameraControlCallback> m_spCallback;
         wil::com_ptr<IMFCameraControlMonitor> m_spMonitor;
         winrt::array_view<ControlData const> m_controls;
+        bool m_isStarted = false;
     };
 }
 

--- a/Samples/WindowsStudio/README.md
+++ b/Samples/WindowsStudio/README.md
@@ -1,8 +1,14 @@
-# C# .Net WinUI & WinRT sample application for using a Windows Studio camera and its set of effects
+#  Windows Studio Effects camera sample application - C# .Net WinUI & WinRT
 
->**This sample will only run fully on a system equipped with a [Windows Studio Effects](https://learn.microsoft.com/en-us/windows/ai/studio-effects/) camera, which in itself requires a NPU and the related Windows Studio Effects driver package installed or pulled-in via Windows Update by the device manufacturer.**
+additional documentation regarding ***[Windows Studio Effect (WSE) and its Driver-Defined Interfaces (DDIs)](/Windows%20Studio%20Effects%20DDIs.md)***
 
-This folder contains a single C# .csproj sample project named **WindowsStudioSample_WinUI** which checks if a Windows Studio Effects camera is available on the system. It then proceeds using WinRT APIs to leverage [extended camera controls](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/kspropertysetid-extendedcameracontrol) standardized in the OS and defined in Windows SDK such as the following 3 implemented as Windows Studio Effects in version 1: 
+>This sample will only run fully on a system equipped with a [Windows Studio Effects (*WSE*)](https://learn.microsoft.com/en-us/windows/ai/studio-effects/) camera, which in itself requires:
+>1. a compatible NPU
+>2. the related Windows Studio Effects driver package installed or pulled-in via Windows Update
+>3. a camera opted into *WSE* by the device manufacturer in its driver. Currently these camera must be front-facing
+
+
+This folder contains a C# sample named **WindowsStudioSample_WinUI** which checks if a Windows Studio Effects camera is available on the system. It then proceeds using WinRT APIs to leverage [extended camera controls](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/kspropertysetid-extendedcameracontrol) standardized in the OS and defined in Windows SDK such as the following 3 implemented as Windows Studio Effects in version 1: 
 - Standard Blur, Portrait Blur and Segmentation Mask Metadata : KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-backgroundsegmentation)*)
 - Eye Contact Standard and Teleprompter: KSPROPERTY_CAMERACONTROL_EXTENDED_EYEGAZECORRECTION (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-eyegazecorrection)*)
 - Automatic Framing: KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow)*) and KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW_CONFIGCAPS (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow-configcaps)*)
@@ -28,7 +34,7 @@ The app demonstrates the following:
        DeviceInformation selectedDeviceInfo = deviceInfoCollection.FirstOrDefault(x => x.EnclosureLocation.Panel == Windows.Devices.Enumeration.Panel.Front);
         ```
     
-2. <a id="WinRT_GET_SET"></a> Check if the newer set of Windows Studio Effects in version 2 are supported. These new DDIs are defined in a new property set ([see DDI documentation](<./Windows Studio Effects DDIs.md>).
+2. [](WinRTGETSET) Check if the newer set of Windows Studio Effects in version 2 are supported. These new DDIs are defined in a new property set ([see DDI documentation](<./Windows Studio Effects DDIs.md>).
     ```csharp
     // New Windows Studio Effects custom KsProperties live under this property set
     public static readonly Guid KSPROPERTYSETID_WindowsStudioEffects = 

--- a/Samples/WindowsStudio/README.md
+++ b/Samples/WindowsStudio/README.md
@@ -17,13 +17,13 @@ The sample leverages [extended camera controls](https://learn.microsoft.com/en-u
 - Automatic Framing: KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow)*) and KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW_CONFIGCAPS (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow-configcaps)*)
 
 ## WSE v2 effects
-It also taps into newer effects available in version 2 that are exposed using a set of DDIs custom to Windows Studio Effects. Since these are exclusive to Windows Studio Effects and shipped outside the OS, their defninition is not part of the Windows SDK and has to be copied into your code base ([see DDI documentation](<./Windows Studio Effects DDIs.md>)):
+It also taps into newer effects available in version 2 that are exposed using a set of DDIs custom to Windows Studio Effects. Since these are exclusive to Windows Studio Effects and shipped outside the OS, their definition is not part of the Windows SDK and has to be copied into your code base ([see DDI documentation](<./Windows Studio Effects DDIs.md>)):
 - Portrait Light (*[DDI documentation](<./Windows Studio Effects DDIs.md#ksproperty_cameracontrol_windowsstudio_stagelight-control>)*)
 - Creative Filters (Animated, Watercolor and Illustrated) (*[DDI documentation](<./Windows Studio Effects DDIs.md#ksproperty_cameracontrol_windowsstudio_creativefilter-control>)*)
 
 ## WSE limits frame formats and profiles
 The code sample allows to see all the MediaTypes (frame formats) exposed by the camera and change the [camera profile](https://learn.microsoft.com/en-us/windows/uwp/audio-video-camera/camera-profiles) it is provisioned with. When initialized with profile for processing effects, *WSE* limits:
-- The number of stream available from a source with effects applied to 1
+- The number of streams available from a source with effects applied to 1
 - Processing of only color stream (i.e. no infrared stream, etc.) 
 - MediaTypes exposed with:
   - Resolutions of at most 2560x1440 and at least 640x360
@@ -37,7 +37,7 @@ That said as alluded to above, these limits are only imposed when the camera pro
 
 **With other profiles however, while these limits are not imposed and instead rely on the capabilities defined by the original camera driver, none of the Windows Studio Effects DDIs are supported**. This is why for example, the Windows Camera Application might not support any effects when entering photo capture mode but offer a different set of MediaTypes to exercise such as with higher resolution and other subtypes.
 
-*WSE* also always defines and exposes a custom *"passthrough"* profile that exposes all MediaTypes available (*[see DDI doc](<./Windows Studio Effects DDIs.md#WSE-custom-profile>)*). This is meant to enable application scenarios such as initializing the camera to record video at higher resolution than 1440p or higher framerate than 30fps when the camera supports these capabilities but is limited by *WSE* in order to apply effects.
+In recent release, *WSE* will define and expose a custom *"passthrough"* profile that exposes all MediaTypes available (*[see DDI doc](<./Windows Studio Effects DDIs.md#WSE-custom-profile>)*). This is meant to enable application scenarios such as initializing the camera to record video at higher resolution than 1440p or higher framerate than 30fps when the camera supports these capabilities but is limited by *WSE* in order to apply effects. The below code sample shows how to query for all supported camera profiles, including this one if available in the *WSE* version on the system.
 
 ## Code walkthrough
 The app demonstrates the following:
@@ -62,7 +62,7 @@ The app demonstrates the following:
     if (MediaCapture.IsVideoProfileSupported(selectedDeviceInfo.Id))
     {
         m_availableCameraProfiles = MediaCapture.FindAllVideoProfiles(selectedDeviceInfo.Id).ToList();
-        // ... see the lookup table "CameraProfileIdLUT" in KsHelper.cs that correlates profile GUIDs with legible names
+        // ... see the lookup table "CameraProfileIdLUT" in KsHelper.cs that correlates profile GUIDs with legible names and see the method IdentifyCompatibleWindowsStudioCamera() that correlates this lookup table with the profiles retrieved with the above call.
     }
 
     // ...

--- a/Samples/WindowsStudio/README.md
+++ b/Samples/WindowsStudio/README.md
@@ -2,16 +2,19 @@
 
 >**This sample will only run fully on a system equipped with a [Windows Studio Effects](https://learn.microsoft.com/en-us/windows/ai/studio-effects/) camera, which in itself requires a NPU and the related Windows Studio Effects driver package installed or pulled-in via Windows Update by the device manufacturer.**
 
-This folder contains a single C# .csproj sample project named **WindowsStudioSample_WinUI** which checks if a Windows Studio Effects camera is available on the system and then gets and sets extended camera controls associated with Windows Studio Effects such as the following 3 introduced in version 1 of Windows Studio Effects: 
-- Background Blur (Standard Blur, Portrait Blur and Segmentation Mask Metadata)
-- Eye Gaze Correction (Standard and Teleprompter)
-- Automatic Framing
+This folder contains a single C# .csproj sample project named **WindowsStudioSample_WinUI** which checks if a Windows Studio Effects camera is available on the system. It then proceeds using WinRT APIs to leverage [extended camera controls](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/kspropertysetid-extendedcameracontrol) standardized in the OS and defined in Windows SDK such as the following 3 implemented as Windows Studio Effects in version 1: 
+- Standard Blur, Portrait Blur and Segmentation Mask Metadata : KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-backgroundsegmentation)*)
+- Eye Contact Standard and Teleprompter: KSPROPERTY_CAMERACONTROL_EXTENDED_EYEGAZECORRECTION (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-eyegazecorrection)*)
+- Automatic Framing: KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow)*) and KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW_CONFIGCAPS (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow-configcaps)*)
 
-as well as the newer effects in version 2 such as 
-- Portrait Light 
-- Creative Filters (Animated, Watercolor and Illustrated)
 
-1. Looks for a Windows Studio camera on the system 
+It also taps into newer effects available in version 2 that are exposed using a set of DDIs custom to Windows Studio Effects. Since these are exclusive to Windows Studio Effects and shipped outside the OS, their defninition is not part of the Windows SDK and has to be copied into your code base ([see DDI documentation](<./Windows Studio Effects DDIs.md>)):
+- Portrait Light (*[DDI documentation](<./Windows Studio Effects DDIs.md#ksproperty_cameracontrol_windowsstudio_stagelight-control>)*)
+- Creative Filters (Animated, Watercolor and Illustrated) (*[DDI documentation](<./Windows Studio Effects DDIs.md#ksproperty_cameracontrol_windowsstudio_creativefilter-control>)*)
+
+The app demonstrates the following:
+
+1. Looks for a Windows Studio camera on the system which must conform to the 2 below criteria:
     
     1. Checks if the system exposes the related Windows Studio dev prop key.
         ```csharp
@@ -25,7 +28,7 @@ as well as the newer effects in version 2 such as
        DeviceInformation selectedDeviceInfo = deviceInfoCollection.FirstOrDefault(x => x.EnclosureLocation.Panel == Windows.Devices.Enumeration.Panel.Front);
         ```
     
-2. Check if the newer set of Windows Studio Effects in version 2 are supported. These new DDIs are defined in a new property set.
+2. Check if the newer set of Windows Studio Effects in version 2 are supported. These new DDIs are defined in a new property set ([see DDI documentation](<./Windows Studio Effects DDIs.md>).
     ```csharp
     // New Windows Studio Effects custom KsProperties live under this property set
     public static readonly Guid KSPROPERTYSETID_WindowsStudioEffects = 

--- a/Samples/WindowsStudio/README.md
+++ b/Samples/WindowsStudio/README.md
@@ -16,26 +16,26 @@ The sample leverages [extended camera controls](https://learn.microsoft.com/en-u
 - Eye Contact Standard and Teleprompter: KSPROPERTY_CAMERACONTROL_EXTENDED_EYEGAZECORRECTION (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-eyegazecorrection)*)
 - Automatic Framing: KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow)*) and KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW_CONFIGCAPS (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow-configcaps)*)
 
-## WSE V2 effects
+## WSE v2 effects
 It also taps into newer effects available in version 2 that are exposed using a set of DDIs custom to Windows Studio Effects. Since these are exclusive to Windows Studio Effects and shipped outside the OS, their defninition is not part of the Windows SDK and has to be copied into your code base ([see DDI documentation](<./Windows Studio Effects DDIs.md>)):
 - Portrait Light (*[DDI documentation](<./Windows Studio Effects DDIs.md#ksproperty_cameracontrol_windowsstudio_stagelight-control>)*)
 - Creative Filters (Animated, Watercolor and Illustrated) (*[DDI documentation](<./Windows Studio Effects DDIs.md#ksproperty_cameracontrol_windowsstudio_creativefilter-control>)*)
 
 ## WSE limits frame formats and profiles
-the code sample allows to see all the MediaTypes (frame formats) exposed by the camera and change the [camera profile](https://learn.microsoft.com/en-us/windows/uwp/audio-video-camera/camera-profiles) it is provisioned with. Windows Studio Effects limits 
-- the number of concurrent stream from a source with effects applied to 1
-- usage of only color streams  
-- MediaType exposed with:
+The code sample allows to see all the MediaTypes (frame formats) exposed by the camera and change the [camera profile](https://learn.microsoft.com/en-us/windows/uwp/audio-video-camera/camera-profiles) it is provisioned with. When initialized with profile for processing effects, *WSE* limits:
+- The number of stream available from a source with effects applied to 1
+- Processing of only color stream (i.e. no infrared stream, etc.) 
+- MediaTypes exposed with:
   - Resolutions of at most 2560x1440 and at least 640x360
   - Framerate of at most 30fps and at least 15fps
-  - Subtype in NV12 format only
+  - Subtype in NV12 format only (*WSE* may take as input other subtypes, but will currently only expose out NV12)
 
-That said, these limits are only imposed when the camera profile used is one of the below [known video profile](https://learn.microsoft.com/en-us/uwp/api/windows.media.capture.knownvideoprofile?view=winrt-26100):
+That said as alluded to above, these limits are only imposed when the camera profile used is one of the below [known video profile](https://learn.microsoft.com/en-us/uwp/api/windows.media.capture.knownvideoprofile?view=winrt-26100):
 - the default (or not specified), also known as *Legacy* profile
 - *VideoRecording*
 - *VideoConferencing*
 
-**With other profiles however, while these limits are not imposed and instead rely on the capabilities defined by the original camera driver, none of the Windows Studio Effects DDIs are supported**. This is why for example, the Windows Camera Application might not support any effects when entering photo capture mode.
+**With other profiles however, while these limits are not imposed and instead rely on the capabilities defined by the original camera driver, none of the Windows Studio Effects DDIs are supported**. This is why for example, the Windows Camera Application might not support any effects when entering photo capture mode but offer a different set of MediaTypes to exercise such as with higher resolution and other subtypes.
 
 *WSE* also always defines and exposes a custom *"passthrough"* profile that exposes all MediaTypes available (*[see DDI doc](<./Windows Studio Effects DDIs.md#WSE-custom-profile>)*). This is meant to enable application scenarios such as initializing the camera to record video at higher resolution than 1440p or higher framerate than 30fps when the camera supports these capabilities but is limited by *WSE* in order to apply effects.
 
@@ -75,12 +75,12 @@ The app demonstrates the following:
          MemoryPreference = MediaCaptureMemoryPreference.Cpu,
          StreamingCaptureMode = StreamingCaptureMode.Video,
          SharingMode = MediaCaptureSharingMode.ExclusiveControl,
-         //Either the default (null) or a specific profile
-         VideoProfile = m_availableCameraProfiles != null ? m_availableCameraProfiles[UIProfilesAvailable.SelectedIndex] : null
+         // Either the default (null) or a specific camera profile
+         VideoProfile = (m_availableCameraProfiles == null ? null : m_availableCameraProfiles[UIProfilesAvailable.SelectedIndex])
      });
     ```
 
-3. <a id="WinRTGETSET"></a> Check if the newer set of Windows Studio Effects in version 2 are supported. These new DDIs are defined in a new property set [see DDI documentation](<./Windows Studio Effects DDIs.md>).
+3. Check if the newer set of Windows Studio Effects in version 2 are supported. These new DDIs are defined in a new property set [see DDI documentation](<./Windows Studio Effects DDIs.md>).
     ```csharp
     // New Windows Studio Effects custom KsProperties live under this property set
     public static readonly Guid KSPROPERTYSETID_WindowsStudioEffects = 

--- a/Samples/WindowsStudio/README.md
+++ b/Samples/WindowsStudio/README.md
@@ -1,6 +1,6 @@
 #  Windows Studio Effects camera sample application - C# .Net WinUI & WinRT
 
-additional documentation regarding ***[Windows Studio Effect (WSE) and its Driver-Defined Interfaces (DDIs)](/Windows%20Studio%20Effects%20DDIs.md)***
+additional documentation regarding ***[Windows Studio Effect (WSE) and its Driver-Defined Interfaces (DDIs)](<./Windows Studio Effects DDIs.md>)***
 
 >This sample will only run fully on a system equipped with a [Windows Studio Effects (*WSE*)](https://learn.microsoft.com/en-us/windows/ai/studio-effects/) camera, which in itself requires:
 >1. a compatible NPU
@@ -21,11 +21,14 @@ It also taps into newer effects available in version 2 that are exposed using a 
 - Portrait Light (*[DDI documentation](<./Windows Studio Effects DDIs.md#ksproperty_cameracontrol_windowsstudio_stagelight-control>)*)
 - Creative Filters (Animated, Watercolor and Illustrated) (*[DDI documentation](<./Windows Studio Effects DDIs.md#ksproperty_cameracontrol_windowsstudio_creativefilter-control>)*)
 
-## WSE frame formats and profiles
-Finally it allows to see all the MediaTypes (frame formats) exposed by the camera and change the [camera profile](https://learn.microsoft.com/en-us/windows/uwp/audio-video-camera/camera-profiles) it is provisioned with. Windows Studio Effects limits the MediaType exposed with:
-- Resolutions of at most 2560x1440 and at least 640x360
-- Framerate of at most 30fps and at least 15fps
-- Subtype in NV12 format only
+## WSE limits frame formats and profiles
+the code sample allows to see all the MediaTypes (frame formats) exposed by the camera and change the [camera profile](https://learn.microsoft.com/en-us/windows/uwp/audio-video-camera/camera-profiles) it is provisioned with. Windows Studio Effects limits 
+- the number of concurrent stream from a source with effects applied to 1
+- usage of only color streams  
+- MediaType exposed with:
+  - Resolutions of at most 2560x1440 and at least 640x360
+  - Framerate of at most 30fps and at least 15fps
+  - Subtype in NV12 format only
 
 That said, these limits are only imposed when the camera profile used is one of the below [known video profile](https://learn.microsoft.com/en-us/uwp/api/windows.media.capture.knownvideoprofile?view=winrt-26100):
 - the default (or not specified), also known as *Legacy* profile
@@ -34,8 +37,7 @@ That said, these limits are only imposed when the camera profile used is one of 
 
 **With other profiles however, while these limits are not imposed and instead rely on the capabilities defined by the original camera driver, none of the Windows Studio Effects DDIs are supported**. This is why for example, the Windows Camera Application might not support any effects when entering photo capture mode.
 
-*WSE* also always defines and exposes a custom *"passthrough"* profile that exposes all MediaTypes available. This is meant to enable application scenarios such as initializing the camera to record video at higher resolution than 1440p or higher framerate than 30fps when the camera supports these capabilities but is limited by *WSE* in order to apply effects.
-
+*WSE* also always defines and exposes a custom *"passthrough"* profile that exposes all MediaTypes available (*[see DDI doc](<./Windows Studio Effects DDIs.md#WSE-custom-profile>)*). This is meant to enable application scenarios such as initializing the camera to record video at higher resolution than 1440p or higher framerate than 30fps when the camera supports these capabilities but is limited by *WSE* in order to apply effects.
 
 ## Code walkthrough
 The app demonstrates the following:
@@ -53,8 +55,32 @@ The app demonstrates the following:
         ```csharp
        DeviceInformation selectedDeviceInfo = deviceInfoCollection.FirstOrDefault(x => x.EnclosureLocation.Panel == Windows.Devices.Enumeration.Panel.Front);
         ```
-    
-2. <a id="WinRTGETSET"></a> Check if the newer set of Windows Studio Effects in version 2 are supported. These new DDIs are defined in a new property set [see DDI documentation](<./Windows Studio Effects DDIs.md>).
+
+2. Checks if camera profiles are supported and initializes a MediaCapture instance with either the selected profile or the default.
+    ```csharp
+    // List all camera profiles exposed by this device
+    if (MediaCapture.IsVideoProfileSupported(selectedDeviceInfo.Id))
+    {
+        m_availableCameraProfiles = MediaCapture.FindAllVideoProfiles(selectedDeviceInfo.Id).ToList();
+        // ... see the lookup table "CameraProfileIdLUT" in KsHelper.cs that correlates profile GUIDs with legible names
+    }
+
+    // ...
+
+    // Initialize MediaCapture instance with a specific camera profile
+     await m_mediaCapture.InitializeAsync(
+     new MediaCaptureInitializationSettings()
+     {
+         VideoDeviceId = selectedDeviceInfo.Id,
+         MemoryPreference = MediaCaptureMemoryPreference.Cpu,
+         StreamingCaptureMode = StreamingCaptureMode.Video,
+         SharingMode = MediaCaptureSharingMode.ExclusiveControl,
+         //Either the default (null) or a specific profile
+         VideoProfile = m_availableCameraProfiles != null ? m_availableCameraProfiles[UIProfilesAvailable.SelectedIndex] : null
+     });
+    ```
+
+3. <a id="WinRTGETSET"></a> Check if the newer set of Windows Studio Effects in version 2 are supported. These new DDIs are defined in a new property set [see DDI documentation](<./Windows Studio Effects DDIs.md>).
     ```csharp
     // New Windows Studio Effects custom KsProperties live under this property set
     public static readonly Guid KSPROPERTYSETID_WindowsStudioEffects = 

--- a/Samples/WindowsStudio/README.md
+++ b/Samples/WindowsStudio/README.md
@@ -28,7 +28,7 @@ The app demonstrates the following:
        DeviceInformation selectedDeviceInfo = deviceInfoCollection.FirstOrDefault(x => x.EnclosureLocation.Panel == Windows.Devices.Enumeration.Panel.Front);
         ```
     
-2. Check if the newer set of Windows Studio Effects in version 2 are supported. These new DDIs are defined in a new property set ([see DDI documentation](<./Windows Studio Effects DDIs.md>).
+2. <a id="WinRT_GET_SET"></a> Check if the newer set of Windows Studio Effects in version 2 are supported. These new DDIs are defined in a new property set ([see DDI documentation](<./Windows Studio Effects DDIs.md>).
     ```csharp
     // New Windows Studio Effects custom KsProperties live under this property set
     public static readonly Guid KSPROPERTYSETID_WindowsStudioEffects = 

--- a/Samples/WindowsStudio/Windows Studio Effects DDIs.md
+++ b/Samples/WindowsStudio/Windows Studio Effects DDIs.md
@@ -1,0 +1,200 @@
+# Windows Studio – Exclusive DDIs
+
+Some of the Windows Studio Effects are driven using standardized Windows DDIs included in the Windows SDK under the [extended camera controls](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/kspropertysetid-extendedcameracontrol) property set:
+- Standard Blur, Portrait Blur and Segmentation Mask Metadata : KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-backgroundsegmentation)*)
+- Eye Contact Standard and Teleprompter: KSPROPERTY_CAMERACONTROL_EXTENDED_EYEGAZECORRECTION (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-eyegazecorrection)*)
+- Automatic Framing: KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow)*) and KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW_CONFIGCAPS (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow-configcaps)*)
+
+However, a newer set of effects supported in version 2 are exposed as DDIs under a different property set:
+
+ - [KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SUPPORTED](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SUPPORTED)
+ - Portrait Light [KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT)
+ - Creative Filters [KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER)
+ - [KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SETNOTIFICATION](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SETNOTIFICATION)
+ - [KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PERFORMANCEMITIGATION](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PERFORMANCEMITIGATION)
+
+~~~cpp
+// Property set exclusive to Windows Studio Effects
+// {C1D740A8-BC18-43F4-A500-6BDF91839FDE}
+static GUID KSPROPERTYSETID_WindowsStudioCameraControl = { 0x1666d655, 0x21a6, 0x4982, 0x97, 0x28, 0x52, 0xc3, 0x9e, 0x86, 0x9f, 0x90 };
+
+// Windows Studio Effects DDIs defined under the KSPROPERTYSETID_WindowsStudioCameraControl property set
+typedef enum {
+    KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SUPPORTED = 0,
+    KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT = 1,
+    KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER = 2,
+    KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SETNOTIFICATION = 3,
+    KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PERFORMANCEMITIGATION = 4
+    // …
+
+} KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PROPERTY;
+~~~
+In order to use them in your code, you would copy those definitions in your header file as they are not included in the Windows SDK.
+
+The payload formats for each of these DDIs are covered below. 
+
+----------
+## <a id="KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SUPPORTED"></a> KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SUPPORTED Control
+This control allows to retrieve a list of supported KSProperties intercepted and implemented specifically by the Windows Studio Effects (*WSE*) camera driver component. Think of it as exclusively a *getter* for which controls corresponding to KSPROPERTY_CAMERACONTROL_EXTENDED_\*, KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_\* and any other custom property set that are implemented directly within *WSE* driver component. It can be preemptively queried before individually proceeding to getting capabilities for each of them if interaction with exclusively the *WSE* driver is desired or simply used to correlate with an existing set of DDI capabilities already fetched to understand if their implementation is provided by *WSE* or another component that is part of the camera driver stack.
+
+### Usage Summary
+| Scope | Control | Type | GET | SET |
+| ----- | ----- | ----- | ----- | ----- |
+| Version 1	| Filter | Synchronous| ✔️ | ❌ |
+
+The SET call of this control will fail.
+
+The KSPROPERTY payload follows the same layout as traditional KSPROPERTY_CAMERACONTROL_EXTENDED_PROPERTY, comprised of a [KSCAMERA_EXTENDEDPROP_HEADER](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) followed by a content of size of *sizeof(KSPROPERTY) \** ***n***
+where ***“n”*** is the count of [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) reported.
+#### KSCAMERA_EXTENDEDPROP_HEADER
+| **Member** | **Description** |
+| ----- | ----- |
+| **Version** |	Must be 1 |
+| **PinId**	| This must be KSCAMERA_EXTENDEDPROP_FILTERSCOPE (0xFFFFFFFF).
+| **Size**	| sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + n * sizeof(KSPROPERTY) where “n” is the count of KSPROPERTY reported |
+| **Result** | Unused, must be 0
+| **Capability** | Unused, must be 0
+| **Flags** | Unused, must be 0
+
+
+for example, a GET call could return the following payload if *WSE* supports all the effects in version 1 and 2, containing a KSCAMERA_EXTENDEDPROP_HEADER struct followed by **8** KSPROPERTY struct :
+| | |
+| ----- | ----- |
+| [KSCAMERA_EXTENDEDPROP_HEADER](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) | *Version* = 1, <br />*PinID* = KSCAMERA_EXTENDEDPROP_FILTERSCOPE <br />*Size* = **8** \* sizeof(KSPROPERTY) <br />*Result* = 0 <br />*Capability* = 0 <br />*Flags* = 0|
+| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION <br />*Flags* = KSPROPERTY_TYPE_GET |
+| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_EXTENDED_EYEGAZECORRECTION <br />*Flags* = KSPROPERTY_TYPE_GET |
+| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW <br />*Flags* = KSPROPERTY_TYPE_GET |
+| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW_CONFIGCAPS <br />*Flags* = KSPROPERTY_TYPE_GET |
+| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT <br />*Flags* = KSPROPERTY_TYPE_GET |
+| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER <br />*Flags* = KSPROPERTY_TYPE_GET |
+| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SETNOTIFICATION <br />*Flags* = KSPROPERTY_TYPE_GET |
+| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PERFORMANCEMITIGATION <br />*Flags* = KSPROPERTY_TYPE_GET |
+
+----------
+## <a id="KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT"></a> KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT Control
+The Stage Light DDI allows to turn ON or OFF the application of the Stage Light effect on the frames. This effect enhances the visual appearance of a face by identifying then processing face pixels with a suite of solutions such as augmenting resolution, removing noise and illumination artifacts, brightening, etc. 
+
+### Usage Summary
+| Scope | Control | Type | GET | SET |
+| ----- | ----- | ----- | ----- | ----- |
+| Version 1	| Filter | Synchronous| ✔️ | ✔️ |
+
+The KSPROPERTY payload follows the same layout as traditional KSPROPERTY_CAMERACONTROL_EXTENDED_PROPERTY, comprised of a [KSCAMERA_EXTENDEDPROP_HEADER](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) followed by a content of size of a [KSCAMERA_EXTENDEDPROP_VALUE](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_value).
+
+~~~cpp
+// Stage Light possible flags values
+#define KSCAMERA_WINDOWSSTUDIO_STAGELIGHT_OFF 0x0000000000000000
+#define KSCAMERA_WINDOWSSTUDIO_STAGELIGHT_ON  0x0000000000000001
+~~~
+
+#### KSCAMERA_EXTENDEDPROP_HEADER
+| **Member** | **Description** |
+| ----- | ----- |
+| **Version** |	Must be 1 |
+| **PinId**	| This must be KSCAMERA_EXTENDEDPROP_FILTERSCOPE (0xFFFFFFFF). |
+| **Size**	| sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_VALUE) |
+| **Result** | Unused, must be 0 |
+| **Capability** | Must at least contain a different valid potential flag value than KSCAMERA_WINDOWSSTUDIO_STAGELIGHT_OFF |
+| **Flags** | KSCAMERA_WINDOWSSTUDIO_STAGELIGHT_OFF or KSCAMERA_WINDOWSSTUDIO_STAGELIGHT_ON |
+
+----------
+## <a id="KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER"></a> KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER Control
+The Creative Filter DDI allows to toggle a pre-defined effect that alters the appearance of a primary subject in the scene. The effect modifies the facial area and potentially also the background of the main subject.
+
+### Usage Summary
+| Scope | Control | Type | GET | SET |
+| ----- | ----- | ----- | ----- | ----- |
+| Version 1	| Filter | Synchronous| ✔️ | ✔️ |
+
+The KSPROPERTY payload follows the same layout as traditional KSPROPERTY_CAMERACONTROL_EXTENDED_PROPERTY, comprised of a [KSCAMERA_EXTENDEDPROP_HEADER](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) followed by a content of size of a [KSCAMERA_EXTENDEDPROP_VALUE](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_value).
+
+~~~cpp
+// Creative Filter possible flags values
+#define KSCAMERA_WINDOWSSTUDIO_CREATIVEFILTER_OFF         0x0000000000000000
+#define KSCAMERA_WINDOWSSTUDIO_CREATIVEFILTER_ILLUSTRATED 0x0000000000000001
+#define KSCAMERA_WINDOWSSTUDIO_CREATIVEFILTER_ANIMATED    0x0000000000000002
+#define KSCAMERA_WINDOWSSTUDIO_CREATIVEFILTER_WATERCOLOR  0x0000000000000004
+~~~
+
+#### KSCAMERA_EXTENDEDPROP_HEADER
+| **Member** | **Description** |
+| ----- | ----- |
+| **Version** |	Must be 1 |
+| **PinId**	| This must be KSCAMERA_EXTENDEDPROP_FILTERSCOPE (0xFFFFFFFF). |
+| **Size**	| sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_VALUE) |
+| **Result** | Unused, must be 0 |
+| **Capability** | Must at least contain a different valid potential flag value than KSCAMERA_WINDOWSSTUDIO_CREATIVEFILTER_OFF |
+| **Flags** |KSCAMERA_WINDOWSSTUDIO_ CREATIVEFILTER_OFF or KSCAMERA_WINDOWSSTUDIO_CREATIVEFILTER_ILLUSTRATED or KSCAMERA_WINDOWSSTUDIO_CREATIVEFILTER_ANIMATED or KSCAMERA_WINDOWSSTUDIO_CREATIVEFILTER_WATERCOLOR |
+
+----------
+## <a id="KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SETNOTIFICATION"></a> KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SETNOTIFICATION Control 
+
+This control is not meant to be used by application and camera session clients. 
+
+It serves as a way for *WSE* driver component to inform other driver components sitting in the driver stack such as a DMFT that an effect DDI state was modified. This may trigger internal changes in these other driver components to accommodate the state change such as disabling or altering pixel processing accordingly. Therefore a driver component that wants to be notified of a Windows Studio Effects DDI state change may expose support for this KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SETNOTIFICATION DDI.
+An example of this could be when *WSE* is requested to turn ON Automatic Framing via the KSProperty KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW; a DeviceMFT may change the way it compensates for lens distortion as to mitigate image quality artifacts when zooming into the fringes of the frame. This notification is sent from *WSE* and relies on each subsequent driver component in the chain to relay it further to the next component. 
+
+**If a driver component intercepts this KSProperty DDI, it shall as well relay it to the subsequent component for both a SET and a GET in which case it needs to aggregate capability from the next component into its own reported capability**
+
+
+### Usage Summary
+| Scope | Control | Type | GET | SET |
+| ----- | ----- | ----- | ----- | ----- |
+| Version 1	| Filter | Synchronous| ✔️ | ✔️ |
+
+***For GET call***: the KSPROPERTY payload follows the same layout as traditional KSPROPERTY_CAMERACONTROL_EXTENDED_PROPERTY, comprised of a [KSCAMERA_EXTENDEDPROP_HEADER](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) followed by a [KSCAMERA_EXTENDEDPROP_VALUE](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_value). 
+The capability field defines which supported SET notifications to receive.
+
+***For SET call***: the KSPROPERTY payload starts in the same layout as traditional KSPROPERTY_CAMERACONTROL_EXTENDED_PROPERTY, comprised of a [KSCAMERA_EXTENDEDPROP_HEADER](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header), but is followed by a variable payload content of **size of a single KSProperty SET payload linked to the KSCAMERA_WINDOWSSTUDIO_SETNOTIFICATION_\* flags value**.
+
+~~~cpp
+// SetNotification possible flags values
+#define KSCAMERA_WINDOWSSTUDIO_SETNOTIFICATION_NONE 0x0000000000000000
+#define KSCAMERA_WINDOWSSTUDIO_SETNOTIFICATION_DIGITALWINDOW 0x0000000000000001
+#define KSCAMERA_WINDOWSSTUDIO_SETNOTIFICATION_EYECORRECTION 0x0000000000000002
+#define KSCAMERA_WINDOWSSTUDIO_SETNOTIFICATION_BACKGROUNDSEGMENTATION 0x0000000000000004
+#define KSCAMERA_WINDOWSSTUDIO_SETNOTIFICATION_STAGELIGHT 0x0000000000000008
+#define KSCAMERA_WINDOWSSTUDIO_SETNOTIFICATION_CREATIVEFILTER 0x0000000000000010
+~~~
+
+#### KSCAMERA_EXTENDEDPROP_HEADER
+| **Member** | **Description** |
+| ----- | ----- |
+| **Version** |	Must be 1 |
+| **PinId**	| This must be KSCAMERA_EXTENDEDPROP_FILTERSCOPE (0xFFFFFFFF). |
+| **Size**	| sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_VALUE) |
+| **Result** | Unused, must be 0 |
+| **Capability** | ***GET call***: Bitmask of notification supported **(KSCAMERA_WINDOWSSTUDIO_ SETNOTIFICATION_\*) for this component and all the subsequent ones up to this point**. Must at least contain a different valid potential flag value than KSCAMERA_WINDOWSSTUDIO_SETNOTIFICATION_NONE. <br /> ***SET call***: Unused, must be 0
+ |
+| **Flags** | ***GET call***: Unused, must be 0. <br /> ***SET call***: One of the KSCAMERA_WINDOWSSTUDIO_ SETNOTIFICATION_* value other than KSCAMERA_WINDOWSSTUDIO_SETNOTIFICATION_NONE.
+ |
+
+ ----------
+## <a id="KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PERFORMANCEMITIGATION"></a>KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PERFORMANCEMITIGATION Control
+This control act as a polling mechanism to identify if the current camera opted into *WSE* can be subject to means of performance mitigation when experiencing for example a dip in framerate due to compute resource contention causing frame processing to take longer than the frame timing deadline. In effect this can take the shape of degrading slightly the quality of an effect in an attempt to lighten the computational load. Having this control allows an app to preemptively advertise this cue to the user as well as query the current state of such mitigation.
+
+### Usage Summary
+| Scope | Control | Type | GET | SET |
+| ----- | ----- | ----- | ----- | ----- |
+| Version 1	| Filter | Synchronous| ✔️ | ❌ |
+
+The SET call of this control will fail.
+
+The KSPROPERTY payload follows the same layout as traditional KSPROPERTY_CAMERACONTROL_EXTENDED_PROPERTY, comprised of a [KSCAMERA_EXTENDEDPROP_HEADER](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) followed by a content of size of *sizeof(KSPROPERTY) \** ***n***
+where ***“n”*** is the count of KSPROPERTY reported.
+
+~~~cpp
+// PerformanceMitigation possible flags values
+#define KSCAMERA_WINDOWSSTUDIO_PERFORMANCEMITIGATION_NONE 0x0000000000000000
+#define KSCAMERA_WINDOWSSTUDIO_PERFORMANCEMITIGATION_EYEGAZECORRECTION_STARE 0x0000000000000001
+~~~
+
+#### KSCAMERA_EXTENDEDPROP_HEADER
+| **Member** | **Description** |
+| ----- | ----- |
+| **Version** |	Must be 1 |
+| **PinId**	| This must be KSCAMERA_EXTENDEDPROP_FILTERSCOPE (0xFFFFFFFF).
+| **Size**	| sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + n * sizeof(KSPROPERTY) where “n” is the count of KSPROPERTY reported |
+| **Result** | Unused, must be 0
+| **Capability** | ***GET call:*** Bitmask of supported flag values (KSCAMERA_WINDOWSSTUDIO_PERFORMANCEMITIGATION_*). Must at least contain a different valid potential flag value than KSCAMERA_WINDOWSSTUDIO_PERFORMANCEMITIGATION_NONE.
+| **Flags** | ***GET call:*** Bitmask of current flag value in operation **(KSCAMERA_WINDOWSSTUDIO_PERFORMANCEMITIGATION_\*)**. For example, if the flags value is KSCAMERA_WINDOWSSTUDIO_PERFORMANCEMITIGATION_NONE, then it means no performance mitigation are currently applied.

--- a/Samples/WindowsStudio/Windows Studio Effects DDIs.md
+++ b/Samples/WindowsStudio/Windows Studio Effects DDIs.md
@@ -12,7 +12,7 @@ the [extended camera controls](https://learn.microsoft.com/en-us/windows-hardwar
 - **Automatic Framing**: KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow)*) and KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW_CONFIGCAPS (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow-configcaps)*)
 
 From an application standpoint, these Windows standardized DDIs can be programmatically interacted with either using:
-- *WinRT*, refer to the example on the [previous page here](.\README.md#WinRT_GET_SET) and in the code sample included in this repo
+- *WinRT*, refer to the example on the [previous page here](.\README.md#WinRTGETSET) and in the code sample included in this repo
 - *Win32* level via the *[IMFExtendedCameraController](https://learn.microsoft.com/en-us/windows/win32/api/mfidl/nn-mfidl-imfextendedcameracontroller)* retrieved from an *IMFMediaSource* followed by 
 an instance of the *[IMFExtendedCameraControl](https://learn.microsoft.com/en-us/windows/win32/api/mfidl/nn-mfidl-imfextendedcameracontrol)* for each control. Here's an example for sending a GET and a SET payload for the **[Eye Contact Standard](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-eyegazecorrection)** DDI.
 ~~~cpp
@@ -80,7 +80,7 @@ typedef enum {
 In order to use these DDIs for *WSE* version 2 in your code, you would copy those definitions into your header file as they are not included in any of the Windows SDK.
 
 From an application standpoint, these *WSE* custom DDIs can be programmatically interacted with either using:
-- *WinRT*, refer to the example on the [previous page here](.\README.md#WinRT_GET_SET) and in the code sample included in this repo
+- *WinRT*, refer to the example on the [previous page here](.\README.md#WinRTGETSET) and in the code sample included in this repo
 - *Win32* level via the the *[IKSControl](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksproxy/nn-ksproxy-ikscontrol)* interface retrieved from an *IMFMediaSource* followed by invoking the *[IKsControl::KsProperty()](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksproxy/nf-ksproxy-ikscontrol-ksproperty)* method with the data payload below prescribed for each of the *WSE* custom DDI. Here's an example for sending a GET and a SET payload for the **[Creative Filters](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER)** custom DDI.
 ~~~cpp
 #include <ks.h>

--- a/Samples/WindowsStudio/Windows Studio Effects DDIs.md
+++ b/Samples/WindowsStudio/Windows Studio Effects DDIs.md
@@ -1,37 +1,191 @@
-# Windows Studio – Exclusive DDIs
+# Windows Studio Effects *(WSE)* driver – Windows DDIs and Exclusive DDIs
 
-Some of the Windows Studio Effects are driven using standardized Windows DDIs included in the Windows SDK under the [extended camera controls](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/kspropertysetid-extendedcameracontrol) property set:
-- Standard Blur, Portrait Blur and Segmentation Mask Metadata : KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-backgroundsegmentation)*)
-- Eye Contact Standard and Teleprompter: KSPROPERTY_CAMERACONTROL_EXTENDED_EYEGAZECORRECTION (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-eyegazecorrection)*)
-- Automatic Framing: KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow)*) and KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW_CONFIGCAPS (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow-configcaps)*)
+The *WSE* driver can be interacted with using APIs which transacts according to a specified Driver-Defined Interface *(DDI)* using a [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) that dictates either a GET or a SET operation, followed by a data payload (*PropertyData*). 
 
-However, a newer set of effects supported in version 2 are exposed as DDIs under a different property set:
 
- - [KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SUPPORTED](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SUPPORTED)
- - Portrait Light [KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT)
- - Creative Filters [KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER)
- - [KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SETNOTIFICATION](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SETNOTIFICATION)
- - [KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PERFORMANCEMITIGATION](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PERFORMANCEMITIGATION)
+
+## Windows standardized DDIs implemented by *WSE*
+Some of the Windows Studio Effects are driven using standardized Windows DDIs included in the Windows SDK under 
+the [extended camera controls](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/kspropertysetid-extendedcameracontrol) property set:
+- **Standard Blur, Portrait Blur and Segmentation Mask Metadata**: KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-backgroundsegmentation)*)
+- **Eye Contact Standard and Teleprompter**: KSPROPERTY_CAMERACONTROL_EXTENDED_EYEGAZECORRECTION (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-eyegazecorrection)*)
+- **Automatic Framing**: KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow)*) and KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW_CONFIGCAPS (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow-configcaps)*)
+
+From an application standpoint, these Windows standardized DDIs can be programmatically interacted with either using:
+- *WinRT*, refer to the example on the [previous page here](.\README.md#WinRT_GET_SET) and in the code sample included in this repo
+- *Win32* level via the *[IMFExtendedCameraController](https://learn.microsoft.com/en-us/windows/win32/api/mfidl/nn-mfidl-imfextendedcameracontroller)* retrieved from an *IMFMediaSource* followed by 
+an instance of the *[IMFExtendedCameraControl](https://learn.microsoft.com/en-us/windows/win32/api/mfidl/nn-mfidl-imfextendedcameracontrol)* for each control. Here's an example for sending a GET and a SET payload for the **[Eye Contact Standard](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-eyegazecorrection)** DDI.
+~~~cpp
+#include <ks.h>
+#include <ksmedia.h>
+
+// Assuming you initialize your camera source "spMediaSource" in your code using IMFCaptureEngine
+wil::com_ptr_nothrow<IMFMediaSource> spMediaSource;
+
+    //... in your method ...
+
+    // Retrieve the IMFExtendedCameraController
+    wil::com_ptr_nothrow<IMFExtendedCameraController> spExtendedCameraController;
+    wil::com_ptr_nothrow<IMFGetService> spGetService;
+    wil::com_ptr_nothrow<IMFExtendedCameraControl> spExtendedCameraControl;
+
+    RETURN_IF_FAILED(spMediaSource->QueryInterface(IID_PPV_ARGS(&spGetService)));
+    RETURN_IF_FAILED(spGetService->GetService(GUID_NULL, IID_PPV_ARGS(&spExtendedCameraController)));
+
+    // If the GET call succeeds
+    if (SUCCEEDED(spExtendedCameraController->GetExtendedCameraControl(MF_CAPTURE_ENGINE_MEDIASOURCE,
+        KSPROPERTY_CAMERACONTROL_EXTENDED_EYEGAZECORRECTION,
+        &spExtendedCameraControl)))
+    {
+        // Check if Eye gaze correction DDI is supported and it is not already ON
+        if (KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_ON & spExtendedCameraControl->GetCapabilities()
+            && (KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_OFF == spExtendedCameraControl->GetFlags()))
+        {
+            // Tell the camera to turn it on.
+            RETURN_IF_FAILED(spExtendedCameraControl->SetFlags(KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_ON));
+            // Write the changed settings to the driver.
+            RETURN_IF_FAILED(spExtendedCameraControl->CommitSettings());
+        }
+    }
+~~~
+
+
+## Custom DDIs implemented by *WSE* driver
+A newer set of effects supported in *WSE* version 2 are exposed as custom DDIs under a different and exclusive property set (***KSPROPERTYSETID_WindowsStudioCameraControl*** defined below) not standardized with a particular Windows SDK:
+
+ - **Portrait Light: [KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT)**
+ - **Creative Filters: [KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER)**
+
+ Furthermore, the Windows Studio driver component exposes additional DDIs that can be useful to applications to advertise some capabilities: 
+ - **[KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SUPPORTED](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SUPPORTED)**
+ - **[KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PERFORMANCEMITIGATION](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PERFORMANCEMITIGATION)**
+
+ Finally, the Windows Studio driver component exposes a DDI useful to other driver components so that they can register to be notified when certain effects are toggled in WSE:
+  - **[KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SETNOTIFICATION](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SETNOTIFICATION)**
 
 ~~~cpp
-// Property set exclusive to Windows Studio Effects
+// Property set exclusive to Windows Studio Effects under which custom DDIs are defined
 // {C1D740A8-BC18-43F4-A500-6BDF91839FDE}
 static GUID KSPROPERTYSETID_WindowsStudioCameraControl = { 0x1666d655, 0x21a6, 0x4982, 0x97, 0x28, 0x52, 0xc3, 0x9e, 0x86, 0x9f, 0x90 };
 
-// Windows Studio Effects DDIs defined under the KSPROPERTYSETID_WindowsStudioCameraControl property set
+// Windows Studio Effects custom DDIs defined under the KSPROPERTYSETID_WindowsStudioCameraControl property set
 typedef enum {
     KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SUPPORTED = 0,
     KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT = 1,
     KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER = 2,
     KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SETNOTIFICATION = 3,
     KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PERFORMANCEMITIGATION = 4
-    // …
-
 } KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PROPERTY;
 ~~~
-In order to use them in your code, you would copy those definitions in your header file as they are not included in the Windows SDK.
+In order to use these DDIs for *WSE* version 2 in your code, you would copy those definitions into your header file as they are not included in any of the Windows SDK.
 
-The payload formats for each of these DDIs are covered below. 
+From an application standpoint, these *WSE* custom DDIs can be programmatically interacted with either using:
+- *WinRT*, refer to the example on the [previous page here](.\README.md#WinRT_GET_SET) and in the code sample included in this repo
+- *Win32* level via the the *[IKSControl](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksproxy/nn-ksproxy-ikscontrol)* interface retrieved from an *IMFMediaSource* followed by invoking the *[IKsControl::KsProperty()](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksproxy/nf-ksproxy-ikscontrol-ksproperty)* method with the data payload below prescribed for each of the *WSE* custom DDI. Here's an example for sending a GET and a SET payload for the **[Creative Filters](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER)** custom DDI.
+~~~cpp
+#include <ks.h>
+#include <ksmedia.h>
+
+// Assuming you initialize your camera source "spMediaSource" in your code using IMFCaptureEngine
+wil::com_ptr_nothrow<IMFMediaSource> spMediaSource;
+
+    //... in your method ...
+
+    // Retrieve the IKsControl interface
+    wil::com_ptr_nothrow<IKsControl> spKsControl;
+    if (SUCCEEDED(spMediaSource->QueryInterface(IID_PPV_ARGS(&spKsControl))))
+    {
+        // Create a GET data payload to send down to the *WSE* driver to query capability
+
+        // First define the target DDI and operation (a GET) using a KSPROPERTY
+        KSPROPERTY creativeFilterGetProperty =
+        {
+            KSPROPERTYSETID_WindowsCameraEffect, // set
+            KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER, // id
+            KSPROPERTY_TYPE_GET // flag
+        };
+
+        // Create the data payload for a GET operation.
+        // The data payload layout follows the specification and is comprised in this case of a KSCAMERA_EXTENDEDPROP_HEADER 
+        // followed by a KSCAMERA_EXTENDEDPROP_VALUE
+        ULONG getCreativeFilterPayloadSizeNeeded = sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_VALUE);
+        wil::unique_cotaskmem_ptr<BYTE[]> spGetCreativeFilterPayload = wil::make_unique_cotaskmem_nothrow<BYTE[]>(getCreativeFilterPayloadSizeNeeded);
+        KSCAMERA_EXTENDEDPROP_HEADER* pExtendedHeader = (KSCAMERA_EXTENDEDPROP_HEADER*)spGetCreativeFilterPayload.get();
+        KSCAMERA_EXTENDEDPROP_VALUE* pValue = (KSCAMERA_EXTENDEDPROP_VALUE*)(pExtendedHeader + 1);
+        
+        // Assign proper values to the payload
+        *pExtendedHeader =
+        {
+            1, // Version
+            KSCAMERA_EXTENDEDPROP_FILTERSCOPE, // PinID
+            getCreativeFilterPayloadSizeNeeded, // Size
+            0, // Result
+            0, // Flags
+            0 // Capability
+        };
+        pValue->Value.ull = 0;
+
+        // Check if CreativeFilter DDI is supported in driver
+        HRESULT hr = spKsControl->KsProperty(
+            &creativeFilterGetProperty,
+            sizeof(KSPROPERTY), 
+            spGetCreativeFilterPayload.get(), 
+            getCreativeFilterPayloadSizeNeeded, 
+            &getCreativeFilterPayloadSizeNeeded);
+
+        // if the DDI is supported and a particular Flags value value reported as supported in the Capability field, 
+        // in this case KSCAMERA_WINDOWSSTUDIO_CREATIVEFILTER_ILLUSTRATED, 
+        // let's now send a SET payload to set that particular Flags value
+        if (SUCCEEDED(hr) && (KSCAMERA_WINDOWSSTUDIO_CREATIVEFILTER_ILLUSTRATED & pExtendedHeader->Capability))
+        {
+            // Define the target DDI and operation (a SET this time) using a KSPROPERTY
+            KSPROPERTY creativeFilterSetProperty =
+            {
+                KSPROPERTYSETID_WindowsCameraEffect, // set
+                KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER, // id
+                KSPROPERTY_TYPE_SET// flag
+            };
+
+            // Create the data payload for a SET operation.
+            // The data payload layout follows the specification and is comprised of a KSCAMERA_EXTENDEDPROP_HEADER 
+            // followed by a KSCAMERA_EXTENDEDPROP_VALUE
+            ULONG setCreativeFilterPayloadSizeNeeded = getCreativeFilterPayloadSizeNeeded;
+            wil::unique_cotaskmem_ptr<BYTE[]> spSetCreativeFilterPayload = wil::make_unique_cotaskmem_nothrow<BYTE[]>(setCreativeFilterPayloadSizeNeeded);
+            KSCAMERA_EXTENDEDPROP_HEADER* pExtendedHeader2 = (KSCAMERA_EXTENDEDPROP_HEADER*)spSetCreativeFilterPayload.get();
+            KSCAMERA_EXTENDEDPROP_VALUE* pValue2 = (KSCAMERA_EXTENDEDPROP_VALUE*)(pExtendedHeader2 + 1);
+            
+            // Assign proper values to the payload
+            *pExtendedHeader2 =
+            {
+                1, // Version
+                KSCAMERA_EXTENDEDPROP_FILTERSCOPE, // PinID
+                getCreativeFilterPayloadSizeNeeded, // Size
+                0, // Result
+                KSCAMERA_WINDOWSSTUDIO_CREATIVEFILTER_ILLUSTRATED, // Flags
+                0 // Capability
+            };
+            pValue->Value.ull = 0;
+
+            // Send a SET payload for the CreativeFilter DDI
+            hr = spKsControl->KsProperty(
+                &creativeFilterSetProperty,
+                sizeof(KSPROPERTY),
+                spSetCreativeFilterPayload.get(),
+                setCreativeFilterPayloadSizeNeeded,
+                &setCreativeFilterPayloadSizeNeeded);
+
+            if (SUCCEEDED(hr))
+            {
+                // we have sucessfully sent our SET payload
+            }
+        }
+    }
+~~~
+
+
+
+# WSE custom DDI specification
+The GET and SET data payload format for each of these custom WSE DDIs is covered below. 
 
 ----------
 ## <a id="KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SUPPORTED"></a> KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SUPPORTED Control
@@ -57,18 +211,18 @@ where ***“n”*** is the count of [KSPROPERTY](https://learn.microsoft.com/en-
 | **Flags** | Unused, must be 0
 
 
-for example, a GET call could return the following payload if *WSE* supports all the effects in version 1 and 2, containing a KSCAMERA_EXTENDEDPROP_HEADER struct followed by **8** KSPROPERTY struct :
-| | |
-| ----- | ----- |
-| [KSCAMERA_EXTENDEDPROP_HEADER](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) | *Version* = 1, <br />*PinID* = KSCAMERA_EXTENDEDPROP_FILTERSCOPE <br />*Size* = **8** \* sizeof(KSPROPERTY) <br />*Result* = 0 <br />*Capability* = 0 <br />*Flags* = 0|
-| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION <br />*Flags* = KSPROPERTY_TYPE_GET |
-| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_EXTENDED_EYEGAZECORRECTION <br />*Flags* = KSPROPERTY_TYPE_GET |
-| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW <br />*Flags* = KSPROPERTY_TYPE_GET |
-| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW_CONFIGCAPS <br />*Flags* = KSPROPERTY_TYPE_GET |
-| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT <br />*Flags* = KSPROPERTY_TYPE_GET |
-| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER <br />*Flags* = KSPROPERTY_TYPE_GET |
-| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SETNOTIFICATION <br />*Flags* = KSPROPERTY_TYPE_GET |
-| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PERFORMANCEMITIGATION <br />*Flags* = KSPROPERTY_TYPE_GET |
+for example, a GET call could return the following payload to be reinterpreted: if *WSE* supports all the effects in version 1 and 2, containing a KSCAMERA_EXTENDEDPROP_HEADER struct followed by **8** KSPROPERTY struct :
+| | | |
+|----- | ----- | ----- |
+|⬇️| [KSCAMERA_EXTENDEDPROP_HEADER](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) | *Version* = 1, <br />*PinID* = KSCAMERA_EXTENDEDPROP_FILTERSCOPE <br />*Size* = **8** \* sizeof(KSPROPERTY) <br />*Result* = 0 <br />*Capability* = 0 <br />*Flags* = 0|
+|⬇️| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION <br />*Flags* = KSPROPERTY_TYPE_GET |
+|⬇️| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_EXTENDED_EYEGAZECORRECTION <br />*Flags* = KSPROPERTY_TYPE_GET |
+|⬇️| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW <br />*Flags* = KSPROPERTY_TYPE_GET |
+|⬇️| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW_CONFIGCAPS <br />*Flags* = KSPROPERTY_TYPE_GET |
+|⬇️| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT <br />*Flags* = KSPROPERTY_TYPE_GET |
+|⬇️| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER <br />*Flags* = KSPROPERTY_TYPE_GET |
+|⬇️| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_SETNOTIFICATION <br />*Flags* = KSPROPERTY_TYPE_GET |
+|🔚| [KSPROPERTY](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-structure) | *Set* = KSPROPERTYSETID_ExtendedCameraControl <br />*Id* = KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_PERFORMANCEMITIGATION <br />*Flags* = KSPROPERTY_TYPE_GET |
 
 ----------
 ## <a id="KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT"></a> KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_STAGELIGHT Control

--- a/Samples/WindowsStudio/Windows Studio Effects DDIs.md
+++ b/Samples/WindowsStudio/Windows Studio Effects DDIs.md
@@ -5,14 +5,14 @@ The *WSE* driver can be interacted with using APIs which transacts according to 
 
 
 ## Windows standardized DDIs implemented by *WSE*
-Some of the Windows Studio Effects are driven using standardized Windows DDIs included in the Windows SDK under 
+Some of the Windows Studio Effects are actionable using standardized Windows DDIs included in the Windows SDK under 
 the [extended camera controls](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/kspropertysetid-extendedcameracontrol) property set:
 - **Standard Blur, Portrait Blur and Segmentation Mask Metadata**: KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-backgroundsegmentation)*)
 - **Eye Contact Standard and Teleprompter**: KSPROPERTY_CAMERACONTROL_EXTENDED_EYEGAZECORRECTION (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-eyegazecorrection)*)
 - **Automatic Framing**: KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow)*) and KSPROPERTY_CAMERACONTROL_EXTENDED_DIGITALWINDOW_CONFIGCAPS (*[DDI documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-digitalwindow-configcaps)*)
 
 From an application standpoint, these Windows standardized DDIs can be programmatically interacted with either using:
-- *WinRT*, refer to the example on the [previous page here](.\README.md#WinRTGETSET) and in the code sample included in this repo
+- *WinRT*, refer to the example on the [previous page here](<./README.md#code-walkthrough>) and in the code sample included in this repo folder
 - *Win32* level via the *[IMFExtendedCameraController](https://learn.microsoft.com/en-us/windows/win32/api/mfidl/nn-mfidl-imfextendedcameracontroller)* retrieved from an *IMFMediaSource* followed by 
 an instance of the *[IMFExtendedCameraControl](https://learn.microsoft.com/en-us/windows/win32/api/mfidl/nn-mfidl-imfextendedcameracontrol)* for each control. Here's an example for sending a GET and a SET payload for the **[Eye Contact Standard](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-eyegazecorrection)** DDI.
 ~~~cpp
@@ -80,7 +80,7 @@ typedef enum {
 In order to use these DDIs for *WSE* version 2 in your code, you would copy those definitions into your header file as they are not included in any of the Windows SDK.
 
 From an application standpoint, these *WSE* custom DDIs can be programmatically interacted with either using:
-- *WinRT*, refer to the example on the [previous page here](.\README.md#WinRTGETSET) and in the code sample included in this repo
+- *WinRT*, refer to the example on the [previous page here](<./README.md#code-walkthrough>) and in the code sample included in this repo folder
 - *Win32* level via the the *[IKSControl](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksproxy/nn-ksproxy-ikscontrol)* interface retrieved from an *IMFMediaSource* followed by invoking the *[IKsControl::KsProperty()](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ksproxy/nf-ksproxy-ikscontrol-ksproperty)* method with the data payload below prescribed for each of the *WSE* custom DDI. Here's an example for sending a GET and a SET payload for the **[Creative Filters](#KSPROPERTY_CAMERACONTROL_WINDOWSSTUDIO_CREATIVEFILTER)** custom DDI.
 ~~~cpp
 #include <ks.h>
@@ -182,7 +182,19 @@ wil::com_ptr_nothrow<IMFMediaSource> spMediaSource;
     }
 ~~~
 
+# WSE custom profile
+*WSE* exposes a custom *"passthrough"* profile that exposes all MediaTypes but prevents usage of any effect DDIs. This profile can be leveraged by application to bypass [stream, resolution and framerate limits](<./README.md#WSE-limits-frame-formats-and-profiles>) imposed by *WSE* for scenarios such as recording at higher resolution when possible. This custom profile definition needs to be copied in your code as it is not a Windows standard profile defined in WDK.
 
+C++
+~~~cpp
+// A custom camera profile specific to Windows Studio that allows through 
+// all MediaTypes on color pin(s) but without effect DDIs support. Useful for
+// example to record videos at resolution or framerate outside the ranges supported
+// to apply effects.
+// {E4ED96D9-CD40-412F-B20A-B7402A43DCD2}
+DEFINE_GUID(KSCAMERAPROFILE_WindowsStudioNoEffectsColorPassthrough,
+    0xe4ed96d9, 0xcd40, 0x412f, 0xb2, 0xa, 0xb7, 0x40, 0x2a, 0x43, 0xdc, 0xd2);
+~~~
 
 # WSE custom DDI specification
 The GET and SET data payload format for each of these custom WSE DDIs is covered below. 

--- a/Samples/WindowsStudio/WindowsStudioSample_WinUI/KsHelper.cs
+++ b/Samples/WindowsStudio/WindowsStudioSample_WinUI/KsHelper.cs
@@ -198,6 +198,24 @@ namespace WindowsStudioSample_WinUI
             public RECT ForegroundBoundingBox;
             //public byte[] MaskData;
         };
+
+        // Lookup table to match a known camera profile ID with a legible name
+        public static readonly Dictionary<string, string> CameraProfileIdLUT =
+            new Dictionary<string, string>()
+            {
+                { "{B4894D81-62B7-4EEC-8740-80658C4A9D3E}", "Legacy" }, // KSCAMERAPROFILE_Legacy
+                { "{A0E517E8-8F8C-4F6F-9A57-46FC2F647EC0}", "VideoRecording" }, // KSCAMERAPROFILE_VideoRecording
+                { "{32440725-961B-4CA3-B5B2-854E719D9E1B}", "HighQualityPhoto" }, // KSCAMERAPROFILE_HighQualityPhoto
+                { "{6B52B017-42C7-4A21-BFE3-23F009149887}", "BalancedVideoAndPhoto" }, // KSCAMERAPROFILE_BalancedVideoAndPhoto
+                { "{C5444A88-E1BF-4597-B2DD-9E1EAD864BB8}", "VideoConferencing" }, // KSCAMERAPROFILE_VideoConferencing
+                { "{02399D9D-4EE8-49BA-BC07-5FF156531413}", "PhotoSequence" }, // KSCAMERAPROFILE_PhotoSequence
+                { "{566E6113-8C35-48E7-B89F-D23FDC1219DC}", "HighFrameRate" }, // KSCAMERAPROFILE_HighFrameRate
+                { "{9FF2CB56-E75A-49B1-A928-9985D5946F87}", "VariablePhotoSequence" }, // KSCAMERAPROFILE_VariablePhotoSequence
+                { "{D4F3F4EC-BDFF-4314-B1D4-008E281F74E7}", "VideoHDR8" }, // KSCAMERAPROFILE_VideoHDR8
+                { "{81361B22-700B-4546-A2D4-C52E907BFC27}", "FaceAuth_Mode" }, // KSCAMERAPROFILE_FaceAuth_Mode
+                { "{E4ED96D9-CD40-412F-B20A-B7402A43DCD2}", "WSENoEffectsColorPassthrough" }, // KSCAMERAPROFILE_WindowsStudioNoEffectsColorPassthrough
+            };
+
         #endregion KsMedia
         //
         // end of redefinition of constant values and structures defined ksmedia.h 

--- a/Samples/WindowsStudio/WindowsStudioSample_WinUI/KsHelper.cs
+++ b/Samples/WindowsStudio/WindowsStudioSample_WinUI/KsHelper.cs
@@ -2,15 +2,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Microsoft.UI.Xaml.Controls;
-using Windows.Foundation;
 using Windows.Graphics.Imaging;
 using Windows.Media.Capture.Frames;
 using Windows.Media.Devices;
-using Windows.Media.MediaProperties;
-using Windows.Storage.Streams;
 using WinRT;
 
 [ComImport]

--- a/Samples/WindowsStudio/WindowsStudioSample_WinUI/MainWindow.xaml
+++ b/Samples/WindowsStudio/WindowsStudioSample_WinUI/MainWindow.xaml
@@ -16,6 +16,7 @@
             <RowDefinition Height="35"/>
             <RowDefinition Height="35"/>
             <RowDefinition Height="35"/>
+            <RowDefinition Height="35"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -85,15 +86,33 @@
          IsEnabled="False">
         </Button>
 
+        <ComboBox
+            x:Name="UIFormatsAvailable"
+            Grid.Column="0"
+            Grid.Row="6"
+            Grid.ColumnSpan="1"
+            IsEnabled="false"
+            SelectionChanged="UIFormatsAvailable_SelectionChanged">
+        </ComboBox>
+
+        <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="6">
+        <TextBlock Text="Camera profile:" VerticalAlignment="Center"/>
+        <ComboBox
+            x:Name="UIProfilesAvailable"
+            IsEnabled="false"
+            SelectionChanged="UIProfilesAvailable_SelectionChanged">
+        </ComboBox>
+        </StackPanel>
+
         <!--Camera preview-->
         <MediaPlayerElement Name="UIPreviewElement"
                       Stretch="Uniform"
                       AreTransportControlsEnabled="False"
-                      Grid.Row="6"
+                      Grid.Row="7"
                       Grid.ColumnSpan="4"/>
 
         <Image Name="UIMaskPreviewElement"
-               Grid.Row="6"
+               Grid.Row="7"
                Grid.Column="4"
                VerticalAlignment="Bottom"/>
     </Grid>

--- a/Samples/WindowsStudio/WindowsStudioSample_WinUI/MainWindow.xaml.cs
+++ b/Samples/WindowsStudio/WindowsStudioSample_WinUI/MainWindow.xaml.cs
@@ -23,15 +23,18 @@ using Microsoft.UI.Xaml.Media.Imaging;
 
 namespace WindowsStudioSample_WinUI;
 /// <summary>
-/// An empty window that can be used on its own or navigated to within a Frame.
+/// Main window class.
 /// </summary>
 public sealed partial class MainWindow : Window
 {
     // Camera related
+    private DeviceInformation m_cameraDeviceInfo;
     private MediaCapture m_mediaCapture;
-    private MediaPlayer m_mediaPlayer;
+    private MediaPlayer m_mediaPlayer = null;
     private MediaFrameSource m_selectedMediaFrameSource;
     private MediaFrameFormat m_selectedFormat;
+    private IEnumerable<MediaFrameFormat> m_availableFormats;
+    private List<MediaCaptureVideoProfile> m_availableCameraProfiles = null;
     private ControlMonitorManager m_controlManager = null;
     private DispatcherQueue m_uiDispatcherQueue = null;
     private MediaFrameReader m_mediaFrameReader = null;
@@ -139,32 +142,62 @@ public sealed partial class MainWindow : Window
     /// <summary>
     /// Uninitialize the camera
     /// </summary>
-    private async Task UninitializeCamera()
+    private void UninitializeCamera()
     {
-        if (m_mediaPlayer != null)
+        // disable UI
+        m_initLock.Wait();
+        try
         {
-            m_mediaPlayer.Source = null;
-            m_mediaPlayer = null;
-        }
-        m_frameReadingLock.Wait();
-        m_backgroundSegmentationImageRefreshLock.Wait();
-        if (m_mediaFrameReader != null)
-        {
-            m_mediaFrameReader.FrameArrived -= MediaFrameReader_FrameArrived;
-            await m_mediaFrameReader.StopAsync();
-            m_mediaFrameReader = null;
-        }
-        if (m_mediaCapture != null)
-        {
-            m_mediaCapture = null;
-        }
-        m_backgroundSegmentationImageRefreshLock.Release();
-        m_frameReadingLock.Release();
+            UIProfilesAvailable.IsEnabled = false;
+            UIFormatsAvailable.IsEnabled = false;
+            UIFormatsAvailable.ItemsSource = null;
+            UIEyeGazeCorrectionModes.IsEnabled = false;
+            UIBackgroundSegmentationModes.IsEnabled = false;
+            UIStageLightSwitch.IsEnabled = false;
+            UICreativeFilterModes.IsEnabled = false;
+            UIAutomaticFramingSwitch.IsEnabled = false;
+            m_availableFormats = null;
 
-        if (m_controlManager != null)
+            if (m_mediaPlayer != null)
+            {
+                m_mediaPlayer.Source = null;
+                m_mediaPlayer = null;
+            }
+
+            if (m_controlManager != null)
+            {
+                m_controlManager.CameraControlChanged -= CameraControlMonitor_ControlChanged;
+                m_controlManager = null;
+            }
+
+            m_frameReadingLock.Wait();
+            m_backgroundSegmentationImageRefreshLock.Wait();
+            try
+            {
+                if (m_mediaFrameReader != null)
+                {
+                    m_mediaFrameReader.FrameArrived -= MediaFrameReader_FrameArrived;
+                    m_mediaFrameReader.StopAsync().Wait();
+                    m_mediaFrameReader = null;
+                }
+
+                m_selectedMediaFrameSource = null;
+                m_selectedFormat = null;
+                if (m_mediaCapture != null)
+                {
+                    m_mediaCapture.Failed -= MediaCapture_Failed;
+                    m_mediaCapture = null;
+                }
+            }
+            finally
+            {
+                m_backgroundSegmentationImageRefreshLock.Release();
+                m_frameReadingLock.Release();
+            }
+        }
+        finally
         {
-            m_controlManager.CameraControlChanged -= CameraControlMonitor_ControlChanged;
-            m_controlManager = null;
+            m_initLock.Release();
         }
 
         m_appState = AppState.Unitialized;
@@ -185,9 +218,14 @@ public sealed partial class MainWindow : Window
         {
             m_initLock.Wait();
 
-            // Attempt to find a Windows Studio camera then initialize a MediaCapture instance
-            // for it and start streaming
-            await InitializeWindowsStudioMediaCaptureAsync();
+            // Attempt to find a Windows Studio camera..
+            if (m_cameraDeviceInfo == null)
+            {
+                m_cameraDeviceInfo = await IdentifyCompatibleWindowsStudioCamera();
+            }
+
+            // Then initialize a MediaCapture instance for this camera and start streaming
+            await InitializeWindowsStudioMediaCaptureAsync(m_cameraDeviceInfo);
 
             // verify if Windows Studio Effects version 2 is supported
             try
@@ -243,14 +281,22 @@ public sealed partial class MainWindow : Window
             m_controlManager.CameraControlChanged += CameraControlMonitor_ControlChanged;
 
             // Refresh UI element associated with Windows Studio effects (version 1)
-            RefreshEyeGazeUI();
-            RefreshBackgroundSegmentationUI();
-            RefreshAutomaticFramingUI();
+            try
+            {
+                RefreshEyeGazeUI();
+                RefreshBackgroundSegmentationUI();
+                RefreshAutomaticFramingUI();
+            }
+            catch (Exception)
+            {
+                // Windows Studio Effects v1 not supported
+                Debug.Print("Windows Studio Effects v1 not supported");
+            }
         }
         catch (Exception ex)
         {
             NotifyUser(ex.Message, NotifyType.ErrorMessage);
-            await UninitializeCamera();
+            UninitializeCamera();
             m_appState = AppState.Error;
         }
         finally
@@ -260,10 +306,10 @@ public sealed partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Initialize a MediaCapture instance for a Windows Studio camera if available on the system
+    /// Search for a camera that supports Windows Studio Effects and return its device information.
     /// </summary>
-    /// <returns></returns>
-    private async Task InitializeWindowsStudioMediaCaptureAsync()
+    /// <returns>DeviceInformation</returns>
+    private async Task<DeviceInformation> IdentifyCompatibleWindowsStudioCamera()
     {
         // Retrieve the list of cameras available on the system with the additional properties
         // that specifies if the system is compatible with Windows Studio
@@ -285,6 +331,37 @@ public sealed partial class MainWindow : Window
             throw new InvalidOperationException("Could not find a front facing camera with Windows Studio Effects");
         }
 
+        // List all camera profiles exposed by this device
+        if (MediaCapture.IsVideoProfileSupported(selectedDeviceInfo.Id))
+        {
+            m_availableCameraProfiles = MediaCapture.FindAllVideoProfiles(selectedDeviceInfo.Id).ToList();
+
+            UIProfilesAvailable.SelectionChanged -= UIProfilesAvailable_SelectionChanged;
+
+            // Attempt to retrieve a legible name for each available profile 
+            UIProfilesAvailable.ItemsSource = m_availableCameraProfiles.Select(
+                profile =>
+                {
+                    string profileName = "";
+                    string profileIdString = profile.Id.Split(',')?.ElementAt(0);
+                    if (profileIdString != null && CameraProfileIdLUT.TryGetValue(profileIdString, out profileName))
+                    {
+                        return profile.Id.Replace(profileIdString, profileName);
+                    }
+                    return profile.Id;
+                });
+            UIProfilesAvailable.SelectedIndex = 0;
+            UIProfilesAvailable.SelectionChanged += UIProfilesAvailable_SelectionChanged;
+        }
+        return selectedDeviceInfo;
+    }
+
+    /// <summary>
+    /// Initialize a MediaCapture instance for a Windows Studio camera if available on the system
+    /// </summary>
+    /// <returns></returns>
+    private async Task InitializeWindowsStudioMediaCaptureAsync(DeviceInformation selectedDeviceInfo)
+    { 
         // Initialize MediaCapture with the Windows Studio camera device id
         m_mediaCapture = new MediaCapture();
 
@@ -296,7 +373,8 @@ public sealed partial class MainWindow : Window
                 VideoDeviceId = selectedDeviceInfo.Id,
                 MemoryPreference = MediaCaptureMemoryPreference.Cpu,
                 StreamingCaptureMode = StreamingCaptureMode.Video,
-                SharingMode = MediaCaptureSharingMode.ExclusiveControl
+                SharingMode = MediaCaptureSharingMode.ExclusiveControl,
+                VideoProfile = m_availableCameraProfiles != null ? m_availableCameraProfiles[UIProfilesAvailable.SelectedIndex] : null
             });
 
         // find the frame source, i.e. the stream or pin we want to use to preview from the Windows Studio camera
@@ -316,7 +394,7 @@ public sealed partial class MainWindow : Window
 
         // Filter MediaType given resolution and framerate preference, and filter out non-compatible subtypes
         // in this case we are looking for a MediaType closest to 1080p @ above 15fps
-        const uint targetFrameRate = 15;
+        const uint targetFramerate = 30;
         const uint targetWidth = 1920;
         const uint targetHeight = 1080;
         bool IsCompatibleSubtype(string subtype)
@@ -327,26 +405,37 @@ public sealed partial class MainWindow : Window
                    || string.Compare(subtype, MediaEncodingSubtypes.Rgb32, true) == 0;
         }
 
-        var formats = m_selectedMediaFrameSource.SupportedFormats.Where(
-                        format => (format.FrameRate.Numerator / format.FrameRate.Denominator) > targetFrameRate
-                                  && IsCompatibleSubtype(format.Subtype))?.OrderBy(
-                                      format => Math.Abs((int)(format.VideoFormat.Width * format.VideoFormat.Height) - (targetWidth * targetHeight)));
-
-        m_selectedFormat = formats.FirstOrDefault();
-
+        m_availableFormats = m_selectedMediaFrameSource.SupportedFormats.Where(
+            format => IsCompatibleSubtype(format.Subtype))?.OrderBy(
+                format => Math.Abs((int)(format.VideoFormat.Width * format.VideoFormat.Height) - (targetWidth * targetHeight))
+                + ((format.FrameRate.Numerator / format.FrameRate.Denominator) - targetFramerate));
+        
+        m_selectedFormat = m_availableFormats.FirstOrDefault();
         if (m_selectedFormat == null)
         {
             throw new Exception($"Could not find a valid frame source format to stream with");
         }
         await m_selectedMediaFrameSource.SetFormatAsync(m_selectedFormat);
 
+        // Update UI with all possible formats available on the stream that can be toggled
+        UIFormatsAvailable.SelectionChanged -= UIFormatsAvailable_SelectionChanged;
+        UIFormatsAvailable.ItemsSource = m_availableFormats.Select(
+            format => $"{format.Subtype}: " +
+                      $"{format.VideoFormat.Width}x{format.VideoFormat.Height}" +
+                      $"@{format.FrameRate.Numerator / format.FrameRate.Denominator}fps");
+        UIFormatsAvailable.SelectedIndex = 0;
+        UIFormatsAvailable.SelectionChanged += UIFormatsAvailable_SelectionChanged;
+
         // Connect the camera to the UI element for previewing the camera
-        m_mediaPlayer = new MediaPlayer();
-        m_mediaPlayer.RealTimePlayback = true;
-        m_mediaPlayer.AutoPlay = true;
+        //if (m_mediaPlayer == null)
+        {
+            m_mediaPlayer = new MediaPlayer();
+            m_mediaPlayer.RealTimePlayback = true;
+            m_mediaPlayer.AutoPlay = true;
+            m_mediaPlayer.CommandManager.IsEnabled = false; // disable playback controls
+        }
         var mediaSource = MediaSource.CreateFromMediaFrameSource(m_selectedMediaFrameSource);
         m_mediaPlayer.Source = mediaSource;
-        m_mediaPlayer.CommandManager.IsEnabled = false; // disable playback controls
 
         UIPreviewElement.SetMediaPlayer(m_mediaPlayer);
 
@@ -371,6 +460,10 @@ public sealed partial class MainWindow : Window
         m_mediaFrameReader = await m_mediaCapture.CreateFrameReaderAsync(m_selectedMediaFrameSource);
         m_mediaFrameReader.FrameArrived += MediaFrameReader_FrameArrived;
         await m_mediaFrameReader.StartAsync();
+
+        // enable UI options to change frame format and camera profile
+        UIFormatsAvailable.IsEnabled = true;
+        UIProfilesAvailable.IsEnabled = (m_availableCameraProfiles != null);
     }
 
     /// <summary>
@@ -430,11 +523,11 @@ public sealed partial class MainWindow : Window
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="errorEventArgs"></param>
-    private async void MediaCapture_Failed(MediaCapture sender, MediaCaptureFailedEventArgs errorEventArgs)
+    private void MediaCapture_Failed(MediaCapture sender, MediaCaptureFailedEventArgs errorEventArgs)
     {
         m_initLock.Wait();
-        NotifyUser(errorEventArgs.Message, NotifyType.ErrorMessage);
-        var t = UninitializeCamera();
+        NotifyUser($"MediaCapture_Failed: {errorEventArgs.Message}", NotifyType.ErrorMessage);
+        UninitializeCamera();
         m_appState = AppState.Error;
         m_initLock.Release();
     }
@@ -466,7 +559,8 @@ public sealed partial class MainWindow : Window
                     break;
 
                 default:
-                    throw new Exception("unhandled control change, implement or allow through at your convenience");
+                    //unhandled control change, implement or allow through at your convenience
+                    break;
             }
         }
         else if (control.controlKind == ControlKind.WindowsStudioEffectsKind)
@@ -707,6 +801,24 @@ public sealed partial class MainWindow : Window
         var uri = new Uri($"ms-controlcenter:studioeffects");
         var fireAndForget = Windows.System.Launcher.LaunchUriAsync(uri);
     }
+
+    private async void UIFormatsAvailable_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (UIFormatsAvailable.IsEnabled)
+        {
+            await m_selectedMediaFrameSource.SetFormatAsync(m_availableFormats.ElementAt(UIFormatsAvailable.SelectedIndex));
+        }
+    }
+
+    private void UIProfilesAvailable_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (UIProfilesAvailable.IsEnabled)
+        {
+            UninitializeCamera();
+            var t = InitializeCameraAndUI(); // fire-forget
+        }
+    }
+
     #endregion UICallbacks
 
 

--- a/Samples/WindowsStudio/WindowsStudioSample_WinUI/MainWindow.xaml.cs
+++ b/Samples/WindowsStudio/WindowsStudioSample_WinUI/MainWindow.xaml.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/Samples/WindowsStudio/WindowsStudioSample_WinUI/MainWindow.xaml.cs
+++ b/Samples/WindowsStudio/WindowsStudioSample_WinUI/MainWindow.xaml.cs
@@ -427,13 +427,10 @@ public sealed partial class MainWindow : Window
         UIFormatsAvailable.SelectionChanged += UIFormatsAvailable_SelectionChanged;
 
         // Connect the camera to the UI element for previewing the camera
-        //if (m_mediaPlayer == null)
-        {
-            m_mediaPlayer = new MediaPlayer();
-            m_mediaPlayer.RealTimePlayback = true;
-            m_mediaPlayer.AutoPlay = true;
-            m_mediaPlayer.CommandManager.IsEnabled = false; // disable playback controls
-        }
+        m_mediaPlayer = new MediaPlayer();
+        m_mediaPlayer.RealTimePlayback = true;
+        m_mediaPlayer.AutoPlay = true;
+        m_mediaPlayer.CommandManager.IsEnabled = false; // disable playback controls
         var mediaSource = MediaSource.CreateFromMediaFrameSource(m_selectedMediaFrameSource);
         m_mediaPlayer.Source = mediaSource;
 


### PR DESCRIPTION
This change 
- adds documentation for Windows Studio Effects DDIs specification and detailing various details of WSE and adding win32 code snippets
- it also changes the code sample to allow changing MediaType and experiment with changing Camera profiles, so see for example how the custom "passthrough" profile exposed by WSE allows the use of higher resolutions but disables support for effects
- fixes some issues with the destructor of the control monitor wrapper class
