### PR TITLE
fix  issue with client-side handling of framerate throttling DDI in sample code

### DIFF
--- a/Samples/ExtendedControlAndMetadata/WinRT_ExtendedControlAndMetadataSample/ExtendedControlAndMetadataSampleApp/ExtendedControlAndMetadataSampleApp.csproj
+++ b/Samples/ExtendedControlAndMetadata/WinRT_ExtendedControlAndMetadataSample/ExtendedControlAndMetadataSampleApp/ExtendedControlAndMetadataSampleApp.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>ExtendedControlAndMetadataSampleApp</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.22621.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.26100.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.22000.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/Samples/ExtendedControlAndMetadata/WinRT_ExtendedControlAndMetadataSample/NuGet.Config
+++ b/Samples/ExtendedControlAndMetadata/WinRT_ExtendedControlAndMetadataSample/NuGet.Config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <config>
-    <add key="repositoryPath" value="$\..\..\..\packages" />
-  </config>
-</configuration>

--- a/Samples/Shared/CameraKsPropertyHelper/CameraKsPropertyHelper.vcxproj
+++ b/Samples/Shared/CameraKsPropertyHelper/CameraKsPropertyHelper.vcxproj
@@ -14,7 +14,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22621.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.22000.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Samples/Shared/CameraKsPropertyHelper/KSHelper.h
+++ b/Samples/Shared/CameraKsPropertyHelper/KSHelper.h
@@ -6,8 +6,8 @@
 
 namespace winrt::CameraKsPropertyHelper::implementation
 {
-    static GUID KSPROPERTYSETID_WindowsCameraEffect =
-    { 0x1666d655, 0x21a6, 0x4982, 0x97, 0x28, 0x52, 0xc3, 0x9e, 0x86, 0x9f, 0x90 };
+    /*static GUID KSPROPERTYSETID_WindowsCameraEffect =
+    { 0x1666d655, 0x21a6, 0x4982, 0x97, 0x28, 0x52, 0xc3, 0x9e, 0x86, 0x9f, 0x90 };*/
 
     // Redefining structs normally available in ksmedia.h but not available due to WINAPI_PARTITION_APP
     //

--- a/Samples/Shared/CameraKsPropertyHelper/PropertyInquiry.cpp
+++ b/Samples/Shared/CameraKsPropertyHelper/PropertyInquiry.cpp
@@ -294,11 +294,12 @@ namespace winrt::CameraKsPropertyHelper::implementation
         {
             // retrieve the GET payload and modify the part we want to send a SET with
             // if we are here we assume user has check for support first
-            auto  getPayload =
+            auto getPayload =
                 GetExtendedCameraControlPayload(
                     controller,
                     static_cast<int>(extendedControlKind));
-            auto pVidProcGetPayload = PropertyValuePayloadHolder<KsVidProcCameraExtendedPropPayload>(getPayload).Payload();
+            auto pPayloadWrapper = PropertyValuePayloadHolder<KsVidProcCameraExtendedPropPayload>(getPayload);
+            KsVidProcCameraExtendedPropPayload* pVidProcGetPayload = pPayloadWrapper.Payload();
 
             pVidProcGetPayload->header.Flags = flags;
 
@@ -364,7 +365,8 @@ namespace winrt::CameraKsPropertyHelper::implementation
                 GetExtendedCameraControlPayload(
                     controller,
                     static_cast<int>(extendedControlKind));
-            auto pVidProcGetPayload = PropertyValuePayloadHolder<KsVidProcCameraExtendedPropPayload>(getPayload).Payload();
+            auto pPayloadWrapper = PropertyValuePayloadHolder<KsVidProcCameraExtendedPropPayload>(getPayload);
+            KsVidProcCameraExtendedPropPayload* pVidProcGetPayload = pPayloadWrapper.Payload();
 
             pVidProcGetPayload->header.Flags = flags;
             pVidProcGetPayload->vidProcSetting.VideoProc.Value.ul = (ULONG)value;


### PR DESCRIPTION
update to 26100 SDK, fix reinterpreted pointer for payload wrapper causing some header values to be mangled