### PR TITLE
fix leak

### DIFF
--- a/Samples/VirtualCamera/VirtualCameraMediaSource/AugmentedMediaSource.cpp
+++ b/Samples/VirtualCamera/VirtualCameraMediaSource/AugmentedMediaSource.cpp
@@ -338,7 +338,7 @@ namespace winrt::WindowsSample::implementation
             }
         }
         m_streamList.reset();
-        (void)m_spPresentationDescriptor.detach(); // calling reset() fails due to the stream also calling reset on its stream descriptor..
+        m_spPresentationDescriptor.reset();
         
         if (m_spEventQueue != nullptr)
         {

--- a/Samples/VirtualCamera/VirtualCameraMediaSource/AugmentedMediaStream.cpp
+++ b/Samples/VirtualCamera/VirtualCameraMediaSource/AugmentedMediaStream.cpp
@@ -139,7 +139,11 @@ namespace winrt::WindowsSample::implementation
 
         for (DWORD i = 0; i < validMediaTypeCount; i++)
         {
-            m_mediaTypeList[i] = sourceStreamMediaTypeList[i];
+            wil::com_ptr_nothrow<IMFMediaType> spSrcStreamMediaType = sourceStreamMediaTypeList[i];
+            if(spSrcStreamMediaType != nullptr)
+            {
+                m_mediaTypeList[i] = spSrcStreamMediaType.detach();
+            }
         }
 
         RETURN_IF_FAILED(MFCreateAttributes(&m_spAttributes, 10));


### PR DESCRIPTION
- Fix augmentedMediaSource shutdown to release presentation descriptor properly.

- Fix double release of MediaType in AugementedMediaStream, where com pointer is assigned to element in unique_cotaskmem_array_ptr that require explicit addref.